### PR TITLE
Update views.py

### DIFF
--- a/api_fhir_r4/views.py
+++ b/api_fhir_r4/views.py
@@ -264,7 +264,7 @@ class ClaimViewSet(BaseFHIRView, mixins.RetrieveModelMixin, mixins.ListModelMixi
         contained = bool(request.GET.get("contained"))
 
         if identifier is not None:
-            queryset = queryset.filter(identifier=identifier)
+            queryset = queryset.filter(Q(code=identifier) | Q(id=identifier) | Q(uuid=identifier))
         else:
             queryset = queryset.filter(validity_to__isnull=True).order_by('validity_from')
             if refDate is not None:


### PR DESCRIPTION
when querying the Claim resource, use 'identifier' in the FHIR query to search 'uuid', 'id' or 'code' fields of the Claim model