### PR TITLE
OE0-11: Add routes if modules are used

### DIFF
--- a/api_fhir_r4/urls.py
+++ b/api_fhir_r4/urls.py
@@ -1,24 +1,42 @@
-
 from api_fhir_r4 import views
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
+from openIMIS.openimisapps import *
+
+
+imis_modules = openimis_apps()
+
 
 router = DefaultRouter()
 router.register(r'login', views.LoginView, basename="login")
-router.register(r'Patient', views.InsureeViewSet, basename="Patient_R4")
-router.register(r'Group', views.GroupViewSet, basename="Group_R4")
-router.register(r'Organisation',views.OrganisationViewSet,basename="Organisation_R4")
-router.register(r'Location', views.LocationViewSet, basename="Location_R4")
-router.register(r'PractitionerRole', views.PractitionerRoleViewSet, basename="PractitionerRole_R4")
-router.register(r'Practitioner', views.PractitionerViewSet, basename="Practitioner_R4")
-router.register(r'Claim', views.ClaimViewSet, basename="Claim_R4")
-router.register(r'ClaimResponse', views.ClaimResponseViewSet, basename="ClaimResponse_R4")
-router.register(r'CommunicationRequest', views.CommunicationRequestViewSet, basename="CommunicationRequest_R4")
-router.register(r'CoverageEligibilityRequest', views.CoverageEligibilityRequestViewSet, basename="CoverageEligibilityRequest_R4")
-router.register(r'Coverage', views.CoverageRequestQuerySet, basename="Coverage_R4")
-router.register(r'Contract', views.ContractViewSet, basename="Contract_R4")
-router.register(r'Medication', views.MedicationViewSet, basename="Medication_R4")
-router.register(r'Condition', views.ConditionViewSet, basename="Condition_R4")
-router.register(r'ActivityDefinition', views.ActivityDefinitionViewSet, basename="ActivityDefinition_R4")
-router.register(r'HealthcareService', views.HealthcareServiceViewSet, basename="HealthcareService_R4")
+# register endpojnt related to Location module if used
+if 'location' in imis_modules:
+    router.register(r'Location', views.LocationViewSet, basename="Location_R4")
+    router.register(r'HealthcareService', views.HealthcareServiceViewSet, basename="HealthcareService_R4")
+# register endpoint for insuree if used
+if 'insuree' in imis_modules:
+    router.register(r'Patient', views.InsureeViewSet, basename="Patient_R4")
+    router.register(r'Group', views.GroupViewSet, basename="Group_R4")
+    router.register(
+        r'CoverageEligibilityRequest', views.CoverageEligibilityRequestViewSet, basename="CoverageEligibilityRequest_R4"
+    )
+# register endpoints related to medical module
+if 'medical' in imis_modules:
+    router.register(r'Medication', views.MedicationViewSet, basename="Medication_R4")
+    router.register(r'Condition', views.ConditionViewSet, basename="Condition_R4")
+    router.register(r'ActivityDefinition', views.ActivityDefinitionViewSet, basename="ActivityDefinition_R4")
+# register all endpoints related to claim based on claim
+if 'claim' in imis_modules:
+    router.register(r'Claim', views.ClaimViewSet, basename="Claim_R4")
+    router.register(r'ClaimResponse', views.ClaimResponseViewSet, basename="ClaimResponse_R4")
+    router.register(r'PractitionerRole', views.PractitionerRoleViewSet, basename="PractitionerRole_R4")
+    router.register(r'Practitioner', views.PractitionerViewSet, basename="Practitioner_R4")
+    router.register(r'CommunicationRequest', views.CommunicationRequestViewSet, basename="CommunicationRequest_R4")
+# register endpoint for policy if used
+if 'policy' in imis_modules:
+    router.register(r'Coverage', views.CoverageRequestQuerySet, basename="Coverage_R4")
+    router.register(r'Contract', views.ContractViewSet, basename="Contract_R4")
+# register endpoint for policy holder if used
+if 'policyholder' in imis_modules:
+    router.register(r'Organisation', views.OrganisationViewSet, basename="Organisation_R4")
 urlpatterns = [path('', include(router.urls))]

--- a/api_fhir_r4/views.py
+++ b/api_fhir_r4/views.py
@@ -4,7 +4,7 @@ from api_fhir_r4.permissions import FHIRApiClaimPermissions, FHIRApiCoverageElig
     FHIRApiHFPermissions, FHIRApiInsureePermissions, FHIRApiMedicationPermissions, FHIRApiConditionPermissions, \
     FHIRApiActivityDefinitionPermissions, FHIRApiHealthServicePermissions, FHIRApiGroupPermissions, \
     FHIRApiOrganizationPermissions
-from claim.models import ClaimAdmin, Claim, Feedback, ClaimItem ,ClaimService
+from claim.models import ClaimAdmin, Claim, Feedback, ClaimItem, ClaimService
 from core.models import User
 from django.db.models import OuterRef, Exists
 from insuree.models import Insuree, InsureePolicy,Family
@@ -27,7 +27,7 @@ from api_fhir_r4.configurations import R4CoverageEligibilityConfiguration as Con
 from api_fhir_r4.serializers import PatientSerializer, LocationSerializer, LocationSiteSerializer, PractitionerRoleSerializer, \
     PractitionerSerializer, ClaimSerializer, CoverageEligibilityRequestSerializer, \
     PolicyCoverageEligibilityRequestSerializer, ClaimResponseSerializer, CommunicationRequestSerializer, \
-    MedicationSerializer, ConditionSerializer, ActivityDefinitionSerializer, HealthcareServiceSerializer ,ContractSerializer,GroupSerializer,\
+    MedicationSerializer, ConditionSerializer, ActivityDefinitionSerializer, HealthcareServiceSerializer, ContractSerializer, GroupSerializer,\
     OrganisationSerializer
 from api_fhir_r4.serializers.coverageSerializer import CoverageSerializer
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setup(
         'openimis-be-insuree',
         'openimis-be-location',
         'openimis-be-claim',
-        'openimis-be-policy'
+        'openimis-be-policy',
+        'openimis-be-policyholder'
     ],
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OE0-11

According to:
"if it is not part of openimis.json in assembly then it is not used but if not used it should not be displayed in the REST API available endpoints"

I imported 'openimis_apps()' so as to have the list of imis modules. Then I checked if module is included in list. If yes - then I can register endpoint related to this module. 