### PR TITLE
OE0-51: InsurancePlan - period and discount extension mapping

### DIFF
--- a/api_fhir_r4/tests/test/test_insurance_plan.json
+++ b/api_fhir_r4/tests/test/test_insurance_plan.json
@@ -11,6 +11,38 @@
             "value":1.0,
             "unit":"months"
          }
+      },
+      {
+         "extension":[
+            {
+               "url":"Percentage",
+               "valueDecimal":40
+            },
+            {
+               "url":"Period",
+               "valueQuantity":{
+                  "value":1,
+                  "unit":"months"
+               }
+            }
+         ],
+         "url":"https://openimis.github.io/openimis_fhir_r4_ig/StructureDefinition/insurance-plan-discount"
+      },
+      {
+         "extension":[
+            {
+               "url":"Percentage",
+               "valueDecimal":30
+            },
+            {
+               "url":"Period",
+               "valueQuantity":{
+                  "value":1,
+                  "unit":"months"
+               }
+            }
+         ],
+         "url":"https://openimis.github.io/openimis_fhir_r4_ig/StructureDefinition/insurance-plan-discount"
       }
    ],
    "identifier":[


### PR DESCRIPTION
NOTE: after merging https://github.com/openimis/openimis-be-api_fhir_r4_py/pull/42 I will rebase this PR to develop. 

TICKET: https://openimis.atlassian.net/browse/OE0-51

improving processing extensions ('period' and 'discount')