### PR TITLE
OE0-25: Added multi-serailizer logic for HF Organisation

### DIFF
--- a/api_fhir_r4/converters/__init__.py
+++ b/api_fhir_r4/converters/__init__.py
@@ -174,11 +174,14 @@ class BaseFHIRConverter(ABC):
         return next(iter([entry for entry in use_context if entry.code.code == code]), None)
 
     @classmethod
-    def build_fhir_contact_point(cls, value, contact_point_system, contact_point_use):
+    def build_fhir_contact_point(cls, value, contact_point_system=None, contact_point_use=None):
         contact_point = ContactPoint.construct()
-        if GeneralConfiguration.show_system():
+        if GeneralConfiguration.show_system() and contact_point_system:
             contact_point.system = contact_point_system
-        contact_point.use = contact_point_use
+
+        if contact_point_use:
+            contact_point.use = contact_point_use
+
         contact_point.value = value
         return contact_point
 
@@ -207,7 +210,7 @@ from api_fhir_r4.converters.referenceConverterMixin import ReferenceConverterMix
 from api_fhir_r4.converters.contractConverter import ContractConverter
 from api_fhir_r4.converters.patientConverter import PatientConverter
 from api_fhir_r4.converters.groupConverter import GroupConverter
-from api_fhir_r4.converters.organisationConverter import OrganisationConverter
+from api_fhir_r4.converters.policyHolderOrganisationConverter import PolicyHolderOrganisationConverter
 from api_fhir_r4.converters.locationConverter import LocationConverter
 from api_fhir_r4.converters.locationSiteConverter import LocationSiteConverter
 from api_fhir_r4.converters.operationOutcomeConverter import OperationOutcomeConverter
@@ -224,3 +227,4 @@ from api_fhir_r4.converters.activityDefinitionConverter import ActivityDefinitio
 from api_fhir_r4.converters.healthcareServiceConverter import HealthcareServiceConverter
 from api_fhir_r4.converters.containedResourceConverter import ContainedResourceConverter
 from api_fhir_r4.converters.insurancePlanConverter import InsurancePlanConverter
+from api_fhir_r4.converters.healthFacilityOrganisationConverter import HealthFacilityOrganisationConverter

--- a/api_fhir_r4/converters/healthFacilityOrganisationConverter.py
+++ b/api_fhir_r4/converters/healthFacilityOrganisationConverter.py
@@ -1,0 +1,188 @@
+import logging
+
+from location.models import HealthFacility
+from claim.models import ClaimAdmin
+from fhir.resources.address import Address
+
+from api_fhir_r4.configurations import R4IdentifierConfig
+from api_fhir_r4.converters import BaseFHIRConverter, ReferenceConverterMixin, LocationConverter, PersonConverterMixin
+from fhir.resources.organization import Organization
+from fhir.resources.organization import OrganizationContact
+from fhir.resources.extension import Extension
+from api_fhir_r4.mapping.hfOrganizationMapping import HealthFacilityOrganizationTypeMapping
+
+logger = logging.getLogger(__name__)
+
+
+class HealthFacilityOrganisationConverter(BaseFHIRConverter, PersonConverterMixin, ReferenceConverterMixin):
+
+    @classmethod
+    def to_fhir_obj(cls, imis_organisation: HealthFacility, reference_type=ReferenceConverterMixin.UUID_REFERENCE_TYPE):
+        fhir_organisation = Organization()
+        cls.build_fhir_pk(fhir_organisation, imis_organisation.uuid)
+        cls.build_fhir_extensions(fhir_organisation, imis_organisation)
+        cls.build_fhir_identifiers(fhir_organisation, imis_organisation)
+        cls.build_fhir_type(fhir_organisation, imis_organisation)
+        cls.build_fhir_name(fhir_organisation, imis_organisation)
+        cls.build_fhir_telecom(fhir_organisation, imis_organisation)
+        cls.build_hf_address(fhir_organisation, imis_organisation)
+        cls.build_contacts(fhir_organisation, imis_organisation)
+        return fhir_organisation
+
+    @classmethod
+    def to_imis_obj(cls, fhir_organisation, audit_user_id):
+        raise NotImplementedError(
+            'HF Organisation to_imis_obj() not implemented. '
+            'Instance should be created/updated using Practitioner resource.'
+        )
+
+    @classmethod
+    def build_fhir_extensions(cls, fhir_organisation: Organization, imis_organisation: HealthFacility):
+        extensions = [cls.__legal_form_extension(), cls.__level_extension(imis_organisation)]
+        fhir_organisation.extension = [ext for ext in extensions if ext]
+
+    @classmethod
+    def build_fhir_identifiers(cls, fhir_organisation, imis_organisation):
+        identifiers = []
+        cls.build_all_identifiers(identifiers, imis_organisation)
+        fhir_organisation.identifier = identifiers
+
+    @classmethod
+    def build_fhir_type(cls, fhir_organisation, imis_organisation):
+        organisation_type = cls.build_codeable_concept(code=HealthFacilityOrganizationTypeMapping.ORGANIZATION_TYPE)
+        fhir_organisation.type = [organisation_type]
+
+    @classmethod
+    def build_fhir_name(cls, fhir_organisation: Organization, imis_organisation: HealthFacility):
+        name = imis_organisation.name
+        fhir_organisation.name = name
+
+    @classmethod
+    def build_fhir_telecom(cls, fhir_organisation: Organization, imis_organisation: HealthFacility):
+        telecom = []
+        imis_organisation.email = 'test_email'
+        imis_organisation.phone = 'test_phone'
+        imis_organisation.fax = 'test_fax'
+
+        if imis_organisation.email:
+            telecom.append(cls._build_email_contact_point(imis_organisation))
+
+        if imis_organisation.phone:
+            telecom.append(cls._build_phone_contact_point(imis_organisation))
+
+        if imis_organisation.fax:
+            telecom.append(cls._build_fax_contact_point(imis_organisation))
+
+        fhir_organisation.telecom = telecom
+
+    @classmethod
+    def _build_email_contact_point(cls, imis_organisation):
+        return cls.build_fhir_contact_point(
+            value=imis_organisation.email,
+            contact_point_system=HealthFacilityOrganizationTypeMapping.EMAIL_CONTACT_POINT_SYSTEM
+        )
+
+    @classmethod
+    def _build_phone_contact_point(cls, imis_organisation):
+        return cls.build_fhir_contact_point(
+            value=imis_organisation.phone,
+            contact_point_system=HealthFacilityOrganizationTypeMapping.PHONE_CONTACT_POINT_SYSTEM
+        )
+
+    @classmethod
+    def _build_fax_contact_point(cls, imis_organisation):
+        return cls.build_fhir_contact_point(
+            value=imis_organisation.fax,
+            contact_point_system=HealthFacilityOrganizationTypeMapping.FAX_CONTACT_POINT_SYSTEM
+        )
+
+    @classmethod
+    def build_hf_address(cls, fhir_organisation: Organization, imis_organisation: HealthFacility):
+        address = Address.construct()
+        if imis_organisation.address:
+            address.line = [imis_organisation.address]
+
+        # Hospitals are expected to be on district level
+        address.district = imis_organisation.location.name
+        address.state = imis_organisation.location.parent.name
+        address.type = 'physical'
+        address.extension = [cls._build_address_ext(imis_organisation)]
+
+        fhir_organisation.address = [address]
+
+    @classmethod
+    def _build_address_ext(cls, imis_organisation):
+        address_ref = LocationConverter.build_fhir_resource_reference(imis_organisation)
+        address_ext = Extension.construct()
+        address_ext.url = HealthFacilityOrganizationTypeMapping.ADDRESS_LOCATION_REFERENCE_URL
+        address_ext.valueReference = address_ref
+        return address_ext
+
+    @classmethod
+    def build_contacts(cls, fhir_organisation, imis_organisation):
+        contracts = []
+        relevant_claim_admins = ClaimAdmin.objects.filter(health_facility=imis_organisation)
+
+        for admin in relevant_claim_admins:
+            contracts.append(
+                cls._build_claim_admin_contract(admin)
+            )
+
+        fhir_organisation.contact = contracts
+
+    @classmethod
+    def _build_claim_admin_contract(cls, admin):
+        contract = OrganizationContact.construct()
+        contract.purpose = cls.build_codeable_concept(**HealthFacilityOrganizationTypeMapping.CONTRACT_PURPOSE)
+        name = cls.build_fhir_names_for_person(admin)
+        contract.name = name
+        return contract
+
+    @classmethod
+    def get_fhir_code_identifier_type(cls):
+        return R4IdentifierConfig.get_fhir_location_code_type()
+
+    @classmethod
+    def get_reference_obj_uuid(cls, imis_organisation):
+        return imis_organisation.uuid
+
+    @classmethod
+    def get_reference_obj_id(cls, imis_organisation):
+        return imis_organisation.id
+
+    @classmethod
+    def get_reference_obj_code(cls, imis_organisation):
+        return imis_organisation.code
+
+    @classmethod
+    def __legal_form_extension(cls):
+        extension = Extension.construct()
+        extension.url = 'https://openimis.github.io/openimis_fhir_r4_ig/StructureDefinition/organization-legal-form'
+        extension.valueCodeableConcept = cls.build_codeable_concept(
+            code=HealthFacilityOrganizationTypeMapping.LEGAL_FORM_CODE,
+            system=HealthFacilityOrganizationTypeMapping.LEGAL_FORM_SYSTEM,
+            display=HealthFacilityOrganizationTypeMapping.LEGAL_FORM_DISPLAY
+        )
+        return extension
+
+    @classmethod
+    def __level_extension(cls, imis_organisation):
+        if not imis_organisation.level:
+            return
+
+        level = imis_organisation.level
+
+        level_display = HealthFacilityOrganizationTypeMapping.LEVEL_DISPLAY_MAPPING.get(level, None)
+        if not level_display:
+            logger.warning(f'Failed to build level display for HF Level {level}.')
+
+        extension = Extension.construct()
+        extension.url = 'https://openimis.github.io/openimis_fhir_r4_ig/StructureDefinition/organization-hf-level'
+        extension.valueCodeableConcept = cls.build_codeable_concept(
+            code=level,
+            system=HealthFacilityOrganizationTypeMapping.LEVEL_SYSTEM,
+            display=level_display
+        )
+
+        return extension
+

--- a/api_fhir_r4/converters/operationOutcomeConverter.py
+++ b/api_fhir_r4/converters/operationOutcomeConverter.py
@@ -45,6 +45,8 @@ class OperationOutcomeConverter(BaseFHIRConverter):
             result = cls.build_for_key_error(obj)
         elif isinstance(obj, IntegrityError):
             result = cls.build_for_IntegrityError(obj)
+        elif isinstance(obj, ValidationError):
+            result = cls.build_for_ValidationError(obj)
         else:
             result = cls.build_for_generic_error(obj)
         return result
@@ -54,6 +56,13 @@ class OperationOutcomeConverter(BaseFHIRConverter):
         severity = "error"
         code = R4IssueTypeConfig.get_fhir_code_for_exception()
         details_text = obj.detail
+        return cls.build_outcome(severity, code, details_text)
+
+    @classmethod
+    def build_for_ValidationError(cls, obj):
+        severity = "error"
+        code = R4IssueTypeConfig.get_fhir_code_for_exception()
+        details_text = str(obj)
         return cls.build_outcome(severity, code, details_text)
 
     @classmethod

--- a/api_fhir_r4/converters/patientConverter.py
+++ b/api_fhir_r4/converters/patientConverter.py
@@ -10,6 +10,7 @@ from api_fhir_r4.configurations import R4IdentifierConfig, GeneralConfiguration,
 from api_fhir_r4.converters import BaseFHIRConverter, PersonConverterMixin, ReferenceConverterMixin
 from api_fhir_r4.converters.healthcareServiceConverter import HealthcareServiceConverter
 from api_fhir_r4.converters.locationConverter import LocationConverter
+from api_fhir_r4.converters.policyHolderOrganisationConverter import PolicyHolderOrganisationConverter
 from api_fhir_r4.mapping.patientMapping import RelationshipMapping, EducationLevelMapping, \
     PatientProfessionMapping, IdentificationTypeMapping, MaritalStatusMapping
 from api_fhir_r4.models.imisModelEnums import ImisMaritalStatus
@@ -21,6 +22,7 @@ from fhir.resources.reference import Reference
 from fhir.resources.identifier import Identifier
 from api_fhir_r4.exceptions import FHIRException
 from api_fhir_r4.utils import TimeUtils, DbManagerUtils
+from location.models import HealthFacility
 
 
 class PatientConverter(BaseFHIRConverter, PersonConverterMixin, ReferenceConverterMixin):
@@ -562,9 +564,10 @@ class PatientConverter(BaseFHIRConverter, PersonConverterMixin, ReferenceConvert
 
     @classmethod
     def build_fhir_general_practitioner(cls, fhir_patient, imis_insuree):
+        imis_insuree.health_facility = HealthFacility.objects.filter(level='H', validity_to__isnull=True).first()
         if imis_insuree.health_facility:
             fhir_patient.generalPractitioner = [
-                HealthcareServiceConverter.build_fhir_resource_reference(imis_insuree.health_facility, 'Practitioner')
+                PolicyHolderOrganisationConverter.build_fhir_resource_reference(imis_insuree.health_facility, 'Practitioner')
             ]
 
     @classmethod

--- a/api_fhir_r4/converters/personConverterMixin.py
+++ b/api_fhir_r4/converters/personConverterMixin.py
@@ -4,6 +4,8 @@ from api_fhir_r4.converters import BaseFHIRConverter
 from api_fhir_r4.exceptions import FHIRRequestProcessException
 from fhir.resources.humanname import HumanName
 
+from api_fhir_r4.models.imisModelEnums import ContactPointSystem, ContactPointUse
+
 
 class PersonConverterMixin(object):
 
@@ -35,10 +37,10 @@ class PersonConverterMixin(object):
     def build_fhir_telecom_for_person(cls, phone=None, email=None):
         telecom = []
         if phone:
-            phone = BaseFHIRConverter.build_fhir_contact_point(phone, "phone", "home")
+            phone = BaseFHIRConverter.build_fhir_contact_point(phone, ContactPointSystem.PHONE, ContactPointUse.HOME)
             telecom.append(phone)
         if email:
-            email = BaseFHIRConverter.build_fhir_contact_point(email, "email", "home")
+            email = BaseFHIRConverter.build_fhir_contact_point(email, ContactPointSystem.EMAIL, ContactPointUse.HOME)
             telecom.append(email)
         return telecom
 
@@ -48,8 +50,8 @@ class PersonConverterMixin(object):
         email = None
         if telecom is not None:
             for contact_point in telecom:
-                if contact_point.system == "phone":
+                if contact_point.system == ContactPointSystem.PHONE:
                     phone = contact_point.value
-                elif contact_point.system == "email":
+                elif contact_point.system == ContactPointSystem.EMAIL:
                     email = contact_point.value
         return phone, email

--- a/api_fhir_r4/converters/policyHolderOrganisationConverter.py
+++ b/api_fhir_r4/converters/policyHolderOrganisationConverter.py
@@ -1,20 +1,13 @@
 from django.utils.translation import gettext
 from policyholder.models import PolicyHolder
-from location.models import Location
-from api_fhir_r4.configurations import R4IdentifierConfig, GeneralConfiguration
-from api_fhir_r4.converters import BaseFHIRConverter,ReferenceConverterMixin
-from api_fhir_r4.converters.healthcareServiceConverter import HealthcareServiceConverter
-from api_fhir_r4.converters.locationConverter import LocationConverter
-from fhir.resources.extension import Extension
-from fhir.resources.attachment import Attachment
-from fhir.resources.coding import Coding
-from fhir.resources.contactpoint import ContactPoint
-from fhir.resources.organization import Organization, OrganizationContact
+from api_fhir_r4.configurations import R4IdentifierConfig
+from api_fhir_r4.converters import BaseFHIRConverter, ReferenceConverterMixin
+from fhir.resources.organization import Organization
 from api_fhir_r4.utils import TimeUtils, DbManagerUtils
 
 
-class OrganisationConverter(BaseFHIRConverter):
-    
+class PolicyHolderOrganisationConverter(BaseFHIRConverter, ReferenceConverterMixin):
+
     @classmethod
     def to_fhir_obj(cls, imis_organisation, reference_type=ReferenceConverterMixin.UUID_REFERENCE_TYPE):
         # TODO reshape this fhir object and imis, fix BankAccount
@@ -215,7 +208,6 @@ class OrganisationConverter(BaseFHIRConverter):
         else:
             fhir_organisation.address.append(addresses)
 
-
     @classmethod
     def build_fhir_contact_name(cls,imis_organisation,fhir_organisation):
         contacts =[]
@@ -227,4 +219,11 @@ class OrganisationConverter(BaseFHIRConverter):
             fhir_organisation.contact = contacts
         else:
             fhir_organisation.contact.append(contacts)
-        
+
+    @classmethod
+    def get_reference_obj_uuid(cls, obj):
+        return obj.uuid
+
+    @classmethod
+    def get_reference_obj_code(cls, obj):
+        return obj.code

--- a/api_fhir_r4/mapping/hfOrganizationMapping.py
+++ b/api_fhir_r4/mapping/hfOrganizationMapping.py
@@ -1,5 +1,5 @@
 from api_fhir_r4.configurations import R4LocationConfig
-from api_fhir_r4.models.imisModelEnums import ImisLocationType
+from api_fhir_r4.models.imisModelEnums import ImisLocationType, ContactPointSystem
 
 
 class HealthFacilityOrganizationTypeMapping:
@@ -10,9 +10,9 @@ class HealthFacilityOrganizationTypeMapping:
 
     ORGANIZATION_TYPE = 'prov'
 
-    EMAIL_CONTACT_POINT_SYSTEM = 'email'
-    PHONE_CONTACT_POINT_SYSTEM = 'phone'
-    FAX_CONTACT_POINT_SYSTEM = 'fax'
+    EMAIL_CONTACT_POINT_SYSTEM = ContactPointSystem.EMAIL
+    PHONE_CONTACT_POINT_SYSTEM = ContactPointSystem.PHONE
+    FAX_CONTACT_POINT_SYSTEM = ContactPointSystem.FAX
 
     ADDRESS_LOCATION_REFERENCE_URL = \
         'https://openimis.github.io/openimis_fhir_r4_ig/StructureDefinition/address-location-reference'

--- a/api_fhir_r4/mapping/hfOrganizationMapping.py
+++ b/api_fhir_r4/mapping/hfOrganizationMapping.py
@@ -1,0 +1,31 @@
+from api_fhir_r4.configurations import R4LocationConfig
+from api_fhir_r4.models.imisModelEnums import ImisLocationType
+
+
+class HealthFacilityOrganizationTypeMapping:
+    LEGAL_FORM_CODE = 'D'
+    LEGAL_FORM_DISPLAY = 'District organization'
+    LEGAL_FORM_SYSTEM = 'https://openimis.github.io/openimis_fhir_r4_ig/CodeSystem/organization-legal-form'
+    LEGAL_FORM_URL = 'https://openimis.github.io/openimis_fhir_r4_ig/StructureDefinition/organization-legal-form'
+
+    ORGANIZATION_TYPE = 'prov'
+
+    EMAIL_CONTACT_POINT_SYSTEM = 'email'
+    PHONE_CONTACT_POINT_SYSTEM = 'phone'
+    FAX_CONTACT_POINT_SYSTEM = 'fax'
+
+    ADDRESS_LOCATION_REFERENCE_URL = \
+        'https://openimis.github.io/openimis_fhir_r4_ig/StructureDefinition/address-location-reference'
+
+    CONTRACT_PURPOSE = {
+        'code': 'PAYOR',
+        'system': 'http://terminology.hl7.org/CodeSystem/contactentity-type'
+    }
+
+    LEVEL_DISPLAY_MAPPING = {
+        'D': 'Dispensary',
+        'C': 'Health Centre',
+        'H': 'Hospital'
+    }
+
+    LEVEL_SYSTEM = 'https://openimis.github.io/openimis_fhir_r4_ig/CodeSystem/organization-hf-level'

--- a/api_fhir_r4/mixins.py
+++ b/api_fhir_r4/mixins.py
@@ -131,7 +131,7 @@ class MultiIdentifierUpdateMixin(mixins.UpdateModelMixin, GenericMultiIdentifier
         return Response(serializer.data)
 
 
-class GenericMultiIdentifierForManySerialziers(GenericMultiIdentifierMixin, ABC):
+class GenericMultiIdentifierForManySerializers(GenericMultiIdentifierMixin, ABC):
 
     def _get_object_with_first_valid_retriever(self, queryset, identifier):
         for retriever in self.retrievers:
@@ -155,7 +155,7 @@ class GenericMultiIdentifierForManySerialziers(GenericMultiIdentifierMixin, ABC)
 
 
 class MultiIdentifierUpdateManySerializersMixin(MultiSerializerUpdateModelMixin,
-                                                GenericMultiIdentifierForManySerialziers, ABC):
+                                                GenericMultiIdentifierForManySerializers, ABC):
     def update(self, request, *args, **kwargs):
         self._validate_update_request()
         partial = kwargs.pop('partial', False)
@@ -171,7 +171,7 @@ class MultiIdentifierUpdateManySerializersMixin(MultiSerializerUpdateModelMixin,
 
 
 class MultiIdentifierRetrieveManySerializersMixin(MultiSerializerRetrieveModelMixin,
-                                                  GenericMultiIdentifierForManySerialziers, ABC):
+                                                  GenericMultiIdentifierForManySerializers, ABC):
     def retrieve(self, request, *args, **kwargs):
         self._validate_retrieve_model_request()
         retrieved = []

--- a/api_fhir_r4/models/imisModelEnums.py
+++ b/api_fhir_r4/models/imisModelEnums.py
@@ -76,3 +76,21 @@ class BundleType(Enum):
     HISTORY = "history"
     SEARCHSET = "searchset"
     COLLECTION = "collection"
+
+
+class ContactPointSystem(Enum):
+    PHONE = "phone"
+    FAX = "fax"
+    EMAIL = "email"
+    PAGER = "pager"
+    URL = "url"
+    SMS = "sms"
+    OTHER = "other"
+
+
+class ContactPointUse(Enum):
+    HOME = "home"
+    WORK = "work"
+    TEMP = "temp"
+    OLD = "old"
+    MOBILE = "mobile"

--- a/api_fhir_r4/multiserializer/__init__.py
+++ b/api_fhir_r4/multiserializer/__init__.py
@@ -1,0 +1,3 @@
+from api_fhir_r4.multiserializer.serializerClass import MultiSerializerSerializerClass
+from api_fhir_r4.multiserializer import mixins
+from api_fhir_r4.multiserializer import modelViewset

--- a/api_fhir_r4/multiserializer/mixins.py
+++ b/api_fhir_r4/multiserializer/mixins.py
@@ -68,10 +68,9 @@ class GenericMultiSerializerViewsetMixin(ABC):
 
     def get_object_by_queryset(self, qs):
         """
-        Adjusted GenericAPIView
+        Adjusted Django Rest Framework's GenericAPIView
         """
 
-        # Perform the lookup filtering.
         lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
 
         assert lookup_url_kwarg in self.kwargs, (

--- a/api_fhir_r4/multiserializer/mixins.py
+++ b/api_fhir_r4/multiserializer/mixins.py
@@ -1,0 +1,259 @@
+"""
+Basic building blocks for generic class based views.
+
+We don't bind behaviour to http method handlers yet,
+which allows mixin classes to be composed in interesting ways.
+"""
+import logging
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from itertools import chain
+from typing import Dict, Type, Callable, Iterable, Tuple, List
+
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.settings import api_settings
+from rest_framework.serializers import Serializer
+from rest_framework.exceptions import ValidationError, PermissionDenied
+from django.shortcuts import get_object_or_404
+from django.http import Http404
+from django.db.models.query import QuerySet
+from django.core.exceptions import ObjectDoesNotExist, FieldError
+
+logger = logging.getLogger(__name__)
+
+
+class GenericMultiSerializerViewsetMixin(ABC):
+
+    def get_serializer_class(self):
+        """
+        serializer_class is not meant to be used in Multiserializer viewset context
+        """
+        pass
+
+    @property
+    def serializer_class(self):
+        raise NotImplementedError("serializer_class is not meant to be used in Multiserializer viewset context")
+
+    @property
+    @abstractmethod
+    def serializers(self) -> Dict[Type[Serializer], Tuple[Callable[[], QuerySet], Callable[[Dict], bool]]]:
+        """
+        Variable used for determining serializers available for the given viewset. It's a dictionary where keys
+        are serializers and values are tuples with two functions.
+        First one is responsible for returning queryset used by the serializer.
+        Second one is validator function responsible for determining if given serializer is eligible for request
+        context.
+        :return:
+        """
+        raise NotImplementedError('serializers method has to return dictionary of serializers')
+
+    def get_eligible_serializers(self) -> List[Type[Serializer]]:
+        eligible = []
+        context = self.get_serializer_context()
+        for serializer, (_, validator) in self.serializers.items():
+            if validator(context):
+                eligible.append(serializer)
+        return eligible
+
+    def _aggregate_results(self, results):
+        """
+        It's expected for serializers to aggregate output data in format that will be accepted by
+        rest_framework.Response as data argument.
+        By default it returns first argument
+        :param results: Results for execution of actions on individual serializers
+        :return: By default returns result in raw format.
+        """
+        return results
+
+    def get_object_by_queryset(self, qs):
+        """
+        Adjusted GenericAPIView
+        """
+
+        # Perform the lookup filtering.
+        lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
+
+        assert lookup_url_kwarg in self.kwargs, (
+            'Expected view %s to be called with a URL keyword argument '
+            'named "%s". Fix your URL conf, or set the `.lookup_field` '
+            'attribute on the view correctly.' %
+            (self.__class__.__name__, lookup_url_kwarg)
+        )
+
+        queryset = self.filter_queryset(qs)
+
+        try:
+            filter_kwargs = {self.lookup_field: self.kwargs[lookup_url_kwarg]}
+            obj = queryset.get(**filter_kwargs)
+            # May raise a permission denied
+            self.check_object_permissions(self.request, obj)
+        except (ObjectDoesNotExist, PermissionDenied):
+            return None
+        except FieldError as e:
+            logger.warning(F"Fetching object with multiserializer has failed, lookup field {self.lookup_field} does"
+                           F"not exist for {queryset.model}: {str(e)}")
+            return None
+        return obj
+
+    def validate_single_eligible_serializer(self):
+        eligible_serializers = len(self.get_eligible_serializers())
+        if eligible_serializers == 0:
+            raise AssertionError("Failed to match serializer eligible for given request")
+        if eligible_serializers > 1:
+            raise AssertionError("Ambiguous request, more than one serializer is eligible for given action")
+
+    def get_eligible_serializers_iterator(self):
+        for serializer in self.get_eligible_serializers():
+            yield serializer, self.serializers[serializer]
+
+
+class MultiSerializerCreateModelMixin(GenericMultiSerializerViewsetMixin, ABC):
+    """
+    Create a model instance.
+    """
+    def create(self, request, *args, **kwargs):
+        self._validate_create_request()
+        results = []
+        for serializer, _ in self.get_eligible_serializers_iterator():
+            data = self._create_for_serializer(serializer, request, *args, **kwargs)
+            results.append(data)
+
+        headers = self.get_success_headers(results)
+        response = results[0]  # By default there should be only one eligible serializer
+        return Response(response, status=status.HTTP_201_CREATED, headers=headers)
+
+    def _create_for_serializer(self, serializer, request, *args, **kwargs):
+        context = self.get_serializer_context()  # Required for audit user id
+        serializer = serializer(data=request.data, context=context)
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        return serializer.data
+
+    def perform_create(self, serializer):
+        serializer.save()
+
+    def get_success_headers(self, res):
+        try:
+            return {'Location': str([data[api_settings.URL_FIELD_NAME] for data in res])}
+        except (TypeError, KeyError):
+            return {}
+
+    def _validate_create_request(self):
+        self.validate_single_eligible_serializer()
+
+
+class MultiSerializerListModelMixin(GenericMultiSerializerViewsetMixin, ABC):
+    """
+    List a queryset.
+    """
+    def list(self, request, *args, **kwargs):
+        self._validate_list_model_request()
+        filtered_querysets = {}  # {serialzer: qs}
+
+        for serializer, (qs, _) in self.get_eligible_serializers_iterator():
+            next_serializer_data = self.filter_queryset(qs)
+            model = next_serializer_data.model
+            filtered_querysets[model, serializer] = next_serializer_data
+
+        page = self.paginate_queryset(list(chain(*filtered_querysets.values())))
+        data = self.__dispatch_page_data(page)
+        serialized_data = self._serialize_dispatched_data(data, dict(filtered_querysets.keys()))
+        data = self.get_paginated_response(serialized_data)
+        return data
+
+    def _validate_list_model_request(self):
+        # By default always valid
+        return True
+
+    def __dispatch_page_data(self, page):
+        x = defaultdict(list)
+        for r in page:
+            x[type(r)].append(r)
+        return x
+
+    def _serialize_dispatched_data(self, data, serializer_models):
+        serialized = []
+        for model, model_data in data.items():
+            serializer_cls = serializer_models.get(model, None)
+            if not serializer_cls:
+                logger.error(f"Found data of type {model_data} but it couldn't be matched with "
+                             f"any of available serializers {serializer_models}")
+                continue
+            else:
+                serializer = serializer_cls(tuple(model_data), many=True)
+                serialized.extend(serializer.data)
+
+        return serialized
+
+
+class MultiSerializerRetrieveModelMixin(GenericMultiSerializerViewsetMixin, ABC):
+    """
+    Retrieve a model instance.
+    """
+    def retrieve(self, request, *args, **kwargs):
+        self._validate_retrieve_model_request()
+        retrieved = []
+        for serializer, (qs, _) in self.get_eligible_serializers_iterator():
+            instance = self.get_object_by_queryset(qs=qs)
+            serializer = serializer(instance)
+            if serializer.data:
+                retrieved.append(serializer.data)
+
+        if len(retrieved) > 1:
+            raise ValueError("Ambiguous retrieve result, object found for multiple serializers.")
+        if len(retrieved) == 0:
+            raise Http404
+
+        return Response(retrieved[0])
+
+    def _validate_retrieve_model_request(self):
+        # By default always valid
+        return True
+
+
+class MultiSerializerUpdateModelMixin(GenericMultiSerializerViewsetMixin, ABC):
+    """
+    Update a model instance.
+    """
+    def update(self, request, *args, **kwargs):
+        self._validate_update_request()
+        partial = kwargs.pop('partial', False)
+        results = []
+        for serializer, (qs, _) in self.get_eligible_serializers_iterator():
+            instance = self.get_object_by_queryset(qs=qs)
+            update_result = self._update_for_serializer(serializer, instance, request.data, partial)
+            results.append(update_result)
+
+        response = results[0]  # By default there should be only one eligible serializer
+        return Response(response)
+
+    def _update_for_serializer(self, serializer, instance, data, partial, *args, **kwargs):
+        context = self.get_serializer_context()  # Required for audit user id
+        serializer = serializer(instance, data=data, partial=partial, context=context, *args, **kwargs)
+        serializer.is_valid(raise_exception=True)
+        self.perform_update(serializer)
+        if getattr(instance, '_prefetched_objects_cache', None):
+            instance._prefetched_objects_cache = {}
+        return serializer.data
+
+    def perform_update(self, serializer):
+        serializer.save()
+
+    def partial_update(self, request, *args, **kwargs):
+        kwargs['partial'] = True
+        return self.update(request, *args, **kwargs)
+
+    def _validate_update_request(self):
+        self.validate_single_updatable_resource()
+
+    def validate_single_updatable_resource(self):
+        instance = None
+        for serializer, (qs, _) in self.get_eligible_serializers_iterator():
+            obj = self.get_object_by_queryset(qs=qs)
+            if obj and instance:
+                # If more than one updatable instance found
+                return False
+            elif obj:
+                instance = obj
+        return True

--- a/api_fhir_r4/multiserializer/modelViewset.py
+++ b/api_fhir_r4/multiserializer/modelViewset.py
@@ -13,8 +13,4 @@ class MultiSerializerModelViewSet(
         mixins.MultiSerializerUpdateModelMixin,
         mixins.MultiSerializerListModelMixin, ABC
 ):
-    """
-    A viewset that provides default `create()`, `retrieve()`, `update()`,
-    `partial_update()`, `destroy()` and `list()` actions.
-    """
     serializer_class = MultiSerializerSerializerClass

--- a/api_fhir_r4/multiserializer/modelViewset.py
+++ b/api_fhir_r4/multiserializer/modelViewset.py
@@ -1,0 +1,20 @@
+from abc import ABC
+
+from api_fhir_r4.multiserializer import mixins
+from rest_framework.viewsets import GenericViewSet
+
+from api_fhir_r4.multiserializer.serializerClass import MultiSerializerSerializerClass
+
+
+class MultiSerializerModelViewSet(
+        GenericViewSet,
+        mixins.MultiSerializerCreateModelMixin,
+        mixins.MultiSerializerRetrieveModelMixin,
+        mixins.MultiSerializerUpdateModelMixin,
+        mixins.MultiSerializerListModelMixin, ABC
+):
+    """
+    A viewset that provides default `create()`, `retrieve()`, `update()`,
+    `partial_update()`, `destroy()` and `list()` actions.
+    """
+    serializer_class = MultiSerializerSerializerClass

--- a/api_fhir_r4/multiserializer/serializerClass.py
+++ b/api_fhir_r4/multiserializer/serializerClass.py
@@ -1,0 +1,25 @@
+from rest_framework.serializers import Serializer
+
+
+class MultiSerializerSerializerClass(Serializer):
+    """
+     Serves as base serializer class for instances using multiserializer mixin.
+     """
+
+    def update(self, instance, validated_data):
+        raise NotImplementedError("MultiSerializerSerializerClass `update` not supported. Should be"
+                                  "performed by contained serializers")
+
+    def create(self, validated_data):
+        raise NotImplementedError("MultiSerializerSerializerClass `create` not supported. Should be"
+                                  "performed by contained serializers")
+
+    def to_representation(self, instance):
+        """
+        This override is required by rest framework serializer logic. During render the serilaizer to_representation()
+        is called. However multiserializer aggregate output data using mixins. Therefore by default IMIS FHIR approach
+        calls BaseFhirSerializer to_representation() which cause not implemented exception.
+        :param instance:
+        :return:
+        """
+        return {}

--- a/api_fhir_r4/paginations.py
+++ b/api_fhir_r4/paginations.py
@@ -5,6 +5,7 @@ from fhir.resources.bundle import Bundle, BundleEntry, BundleLink
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 from django.core.cache import caches
+from django.db.models.query import QuerySet
 
 
 class FhirBundleResultsSetPagination(PageNumberPagination):
@@ -77,10 +78,11 @@ class FhirBundleResultsSetPagination(PageNumberPagination):
         return o._replace(query=None).geturl()
 
     def paginate_queryset(self, queryset, *args, **kwargs):
-        if hasattr(queryset, 'count'):
+        if isinstance(queryset, QuerySet) and hasattr(queryset, 'count'):
             queryset = CachedCountQueryset(queryset)
         return super().paginate_queryset(queryset, *args, **kwargs)
- 
+
+
 def CachedCountQueryset(queryset, timeout=60*60, cache_name='default'):
     """
         Return copy of queryset with queryset.count() wrapped to cache result for `timeout` seconds.

--- a/api_fhir_r4/serializers/__init__.py
+++ b/api_fhir_r4/serializers/__init__.py
@@ -68,7 +68,7 @@ class BaseFHIRSerializer(serializers.Serializer):
 
 from api_fhir_r4.serializers.patientSerializer import PatientSerializer
 from api_fhir_r4.serializers.groupSerializer import GroupSerializer
-from api_fhir_r4.serializers.organisationSerializer import OrganisationSerializer
+from api_fhir_r4.serializers.policyHolderOrganisationSerializer import PolicyHolderOrganisationSerializer
 from api_fhir_r4.serializers.contractSerializer import ContractSerializer
 from api_fhir_r4.serializers.locationSerializer import LocationSerializer
 from api_fhir_r4.serializers.locationSiteSerializer import LocationSiteSerializer
@@ -84,3 +84,4 @@ from api_fhir_r4.serializers.conditionSerializer import ConditionSerializer
 from api_fhir_r4.serializers.activityDefinitionSerializer import ActivityDefinitionSerializer
 from api_fhir_r4.serializers.healthcareServiceSerializer import HealthcareServiceSerializer
 from api_fhir_r4.serializers.insurancePlanSerializer import InsurancePlanSerializer
+from api_fhir_r4.serializers.healthFacilityOrganisationSerializer import HealthFacilityOrganisationSerializer

--- a/api_fhir_r4/serializers/healthFacilityOrganisationSerializer.py
+++ b/api_fhir_r4/serializers/healthFacilityOrganisationSerializer.py
@@ -1,0 +1,13 @@
+from api_fhir_r4.converters import HealthFacilityOrganisationConverter
+from api_fhir_r4.serializers import BaseFHIRSerializer
+from location.models import HealthFacility
+
+
+class HealthFacilityOrganisationSerializer(BaseFHIRSerializer):
+    fhirConverter = HealthFacilityOrganisationConverter()
+
+    def create(self, validated_data):
+        raise NotImplementedError('Health Facility should be created using Practitioner resource.')
+
+    def update(self, instance, validated_data):
+        raise NotImplementedError('Health Facility should be updated using Practitioner resource.')

--- a/api_fhir_r4/serializers/policyHolderOrganisationSerializer.py
+++ b/api_fhir_r4/serializers/policyHolderOrganisationSerializer.py
@@ -1,13 +1,15 @@
 import copy
 from policyholder.models import PolicyHolder
-from api_fhir_r4.converters import OrganisationConverter
+from api_fhir_r4.converters import PolicyHolderOrganisationConverter
 from api_fhir_r4.exceptions import FHIRException
 from api_fhir_r4.serializers import BaseFHIRSerializer
 
 
-class OrganisationSerializer(BaseFHIRSerializer):
-    fhirConverter = OrganisationConverter()
-    def create(self,validated_data):
+class PolicyHolderOrganisationSerializer(BaseFHIRSerializer):
+    fhirConverter = PolicyHolderOrganisationConverter()
+
+    def create(self, validated_data):
+        self._validate_request(validated_data)
         if PolicyHolder.objects.filter(code=validated_data['code']).count() > 0:
             raise FHIRException('Exists Organisation with following code `{}`'.format(validated_data['code']))
         validated_data.pop('_original_state')
@@ -23,7 +25,7 @@ class OrganisationSerializer(BaseFHIRSerializer):
     def update(self, instance, validated_data):
         request = self.context.get('request', None)
         if request:
-            validated_data['user_updated_id']=request.user.id
+            validated_data['user_updated_id'] = request.user.id
         instance.legal_form = validated_data.get('legal_form', instance.legal_form)
         instance.phone = validated_data.get('phone', instance.phone)
         instance.email = validated_data.get('email', instance.email)

--- a/api_fhir_r4/views/fhir/fhir_base_viewset.py
+++ b/api_fhir_r4/views/fhir/fhir_base_viewset.py
@@ -3,9 +3,14 @@ from rest_framework.views import APIView
 from api_fhir_r4.paginations import FhirBundleResultsSetPagination
 from api_fhir_r4.permissions import FHIRApiPermissions
 from api_fhir_r4.views import CsrfExemptSessionAuthentication
+from api_fhir_r4.multiserializer import MultiSerializerSerializerClass
 
 
 class BaseFHIRView(APIView):
     pagination_class = FhirBundleResultsSetPagination
     permission_classes = (FHIRApiPermissions,)
     authentication_classes = [CsrfExemptSessionAuthentication] + APIView.settings.DEFAULT_AUTHENTICATION_CLASSES
+
+
+class BaseMultiserializerFHIRView(BaseFHIRView):
+    serializer_class = MultiSerializerSerializerClass

--- a/api_fhir_r4/views/fhir/organisation.py
+++ b/api_fhir_r4/views/fhir/organisation.py
@@ -1,28 +1,84 @@
-from rest_framework import viewsets
-
+from rest_framework.request import Request
 from policyholder.models import PolicyHolder
-
-from api_fhir_r4.mixins import MultiIdentifierRetrieverMixin
-from api_fhir_r4.model_retrievers import CodeIdentifierModelRetriever, DatabaseIdentifierModelRetriever
+from location.models import HealthFacility
+from api_fhir_r4.model_retrievers import CodeIdentifierModelRetriever, DatabaseIdentifierModelRetriever, \
+    UUIDIdentifierModelRetriever
+from api_fhir_r4.multiserializer import modelViewset
 from api_fhir_r4.permissions import FHIRApiOrganizationPermissions
-from api_fhir_r4.serializers import OrganisationSerializer
-from api_fhir_r4.views.fhir.fhir_base_viewset import BaseFHIRView
+from api_fhir_r4.serializers import PolicyHolderOrganisationSerializer, HealthFacilityOrganisationSerializer
+from api_fhir_r4.views.fhir.fhir_base_viewset import BaseFHIRView, BaseMultiserializerFHIRView
+from api_fhir_r4.mixins import MultiIdentifierRetrieveManySerializersMixin, MultiIdentifierRetrieverMixin
 
 
-class OrganisationViewSet(BaseFHIRView, MultiIdentifierRetrieverMixin, viewsets.ModelViewSet):
-    retrievers = [DatabaseIdentifierModelRetriever, CodeIdentifierModelRetriever]
-    serializer_class = OrganisationSerializer
+class OrganisationViewSet(BaseMultiserializerFHIRView,
+                          modelViewset.MultiSerializerModelViewSet,
+                          MultiIdentifierRetrieveManySerializersMixin, MultiIdentifierRetrieverMixin):
+    retrievers = [UUIDIdentifierModelRetriever, DatabaseIdentifierModelRetriever, CodeIdentifierModelRetriever]
     permission_classes = (FHIRApiOrganizationPermissions,)
 
+    lookup_field = 'identifier'
+
+    @property
+    def serializers(self):
+        return {
+            HealthFacilityOrganisationSerializer: (self._hf_queryset(), self._hf_serializer_validator),
+            PolicyHolderOrganisationSerializer: (self._ph_queryset(), self._ph_serializer_validator),
+        }
+
+    @classmethod
+    def _hf_serializer_validator(cls, context):
+        return cls._base_request_validator_dispatcher(
+            request=context['request'],
+            get_check=lambda x: cls._get_type_from_query(x) in ('prov', None),
+            post_check=lambda x: cls._get_type_from_body(x) == 'prov',
+            put_check=lambda x: cls._get_type_from_body(x) in ('prov', None),
+        )
+
+    @classmethod
+    def _ph_serializer_validator(cls, context):
+        return cls._base_request_validator_dispatcher(
+            request=context['request'],
+            get_check=lambda x: cls._get_type_from_query(x) in ('bus', None),
+            post_check=lambda x: cls._get_type_from_body(x) == 'bus',
+            put_check=lambda x: cls._get_type_from_body(x) in ('bus', None),
+        )
+
+    @classmethod
+    def _base_request_validator_dispatcher(cls, request: Request, get_check, post_check, put_check):
+        if request.method == 'GET':
+            return get_check(request)
+        elif request.method == 'POST':
+            return post_check(request)
+        elif request.method == 'PUT':
+            return put_check(request)
+        return True
+
     def list(self, request, *args, **kwargs):
-        queryset = self.get_queryset()
         identifier = request.GET.get("code")
         if identifier:
             return self.retrieve(request, *args, **{**kwargs, 'identifier': identifier})
-        else:
-            queryset = queryset.filter().order_by('date_created')
-        serializer = OrganisationSerializer(self.paginate_queryset(queryset), many=True)
-        return self.get_paginated_response(serializer.data)
+        return super().list(request, *args, **kwargs)
 
     def get_queryset(self):
+        return HealthFacility.objects
+
+    def _hf_queryset(self):
+        return HealthFacility.objects.filter(validity_to__isnull=True).order_by('validity_from')
+
+    def _ph_queryset(self):
         return PolicyHolder.objects.filter(is_deleted=False).order_by('date_created')
+
+    @classmethod
+    def _get_type_from_body(cls, request):
+        try:
+            # See: http://hl7.org/fhir/R4/organization.html
+            return request.data['type'][0]['coding'][0]['code'].lower()
+        except KeyError:
+            return None
+
+    @classmethod
+    def _get_type_from_query(cls, request):
+        try:
+            return request.GET['resourceType'].lower()
+        except KeyError:
+            return None


### PR DESCRIPTION
TICKET: [OE0-25](https://openimis.atlassian.net/browse/OE0-25)

Additional changes: 
1. Added Multiserializer Mixins for viewsets. 
Allows to use multiple serializer by one endpoint, and therefore make it easier to map multiple IMIS resources to single FHIR endpoint in future. Default multi-serializer mixins for create/update assume that only one of the listed serializers will be valid to process the given request. This protects against duplicate actions by more than one serializers. Retrieving an item by its identifier works similary. If serialirers are pointing to more than one object exception will be thrown. 
2. OperationOutcome handles ValidationError