### PR TITLE
OE0-67: ActivityDefinition workflow use context should be optional

### DIFF
--- a/api_fhir_r4/tests/mixin/activityDefinitionTestMixin.py
+++ b/api_fhir_r4/tests/mixin/activityDefinitionTestMixin.py
@@ -222,7 +222,7 @@ class ActivityDefinitionTestMixin(GenericTestMixin):
                                      [WorkflowMapping.fhir_workflow_coding[self._TEST_SERVICE_CATEGORY]])
         self.verify_fhir_use_context(fhir_obj, UseContextMapping.fhir_use_context_coding["venue"],
                                      [VenueMapping.fhir_venue_coding[Service.CARE_TYPE_IN_PATIENT],
-                                     VenueMapping.fhir_venue_coding[Service.CARE_TYPE_OUT_PATIENT]])
+                                      VenueMapping.fhir_venue_coding[Service.CARE_TYPE_OUT_PATIENT]])
 
     def verify_fhir_identifier(self, fhir_obj, identifier_type, expected_identifier_value):
         identifiers = [identifier for identifier in fhir_obj.identifier

--- a/api_fhir_r4/tests/test_activityDefinitionConverter.py
+++ b/api_fhir_r4/tests/test_activityDefinitionConverter.py
@@ -30,6 +30,7 @@ class ActivityDefinitionConverterTestCase(ActivityDefinitionTestMixin):
         self.verify_imis_instance(imis_service)
 
     def test_create_object_from_json(self):
-        dict_activity_definition = json.loads(ActivityDefinitionConverterTestCase.__TEST_ACTIVITY_DEFINITION_JSON_TEXT__)
+        dict_activity_definition = json.loads(
+            ActivityDefinitionConverterTestCase.__TEST_ACTIVITY_DEFINITION_JSON_TEXT__)
         fhir_activity_definition = ActivityDefinition(**dict_activity_definition)
         self.verify_fhir_instance(fhir_activity_definition)

--- a/api_fhir_r4/tests/test_timeUtils.py
+++ b/api_fhir_r4/tests/test_timeUtils.py
@@ -7,26 +7,30 @@ from api_fhir_r4.utils import TimeUtils
 
 
 class TimeUtilsTestCase(TestCase):
-
     __OFFSET_IN_SECONDS = 3600
 
-    """
     def test_str_converting_datetime(self):
         str_value = "2010-11-16T15:22:01"
         expected = core.datetime.datetime(2010, 11, 16, 15, 22, 1, 0)
-        actual = TimeUtils.str_to_date(str_value)
+        actual = TimeUtils.str_iso_to_date(str_value)
         self.assertEqual(expected, actual)
 
     def test_str_converting_datetime_with_time_zone(self):
         str_value = "2010-11-16T15:22:01+01:00"
         expected = core.datetime.datetime(2010, 11, 16, 15, 22, 1, 0,
                                           tzinfo=dateutil.tz.tzoffset(None, self.__OFFSET_IN_SECONDS))
-        actual = TimeUtils.str_to_date(str_value)
+        actual = TimeUtils.str_iso_to_date(str_value)
         self.assertEqual(expected, actual)
-    """
 
     def test_str_converting_date(self):
         str_value = "2010-11-16"
         expected = core.datetime.date(2010, 11, 16)
         actual = TimeUtils.str_to_date(str_value)
+        self.assertEqual(expected, actual)
+
+    def test_str_converting_date_and_time(self):
+        str_date_value = "2010-11-16"
+        str_time_value = "01:02:03"
+        expected = core.datetime.datetime(2010, 11, 16, 1, 2, 3)
+        actual = TimeUtils.str_to_date(str_date_value, str_time_value)
         self.assertEqual(expected, actual)


### PR DESCRIPTION
Changes:
- `ActivityDefinition` age, gender and workflow contexts are now optional
- Fixed `TimeUtils` tests

[https://openimis.atlassian.net/browse/OE0-67](https://openimis.atlassian.net/browse/OE0-67)