### PR TITLE
OAI-61: Insuree photo url use localhost if site root is empty

### DIFF
--- a/api_fhir_r4/converters/patientConverter.py
+++ b/api_fhir_r4/converters/patientConverter.py
@@ -513,7 +513,9 @@ class PatientConverter(BaseFHIRConverter, PersonConverterMixin, ReferenceConvert
     def build_fhir_photo(cls, fhir_patient, imis_insuree):
         if imis_insuree.photo and imis_insuree.photo.folder and imis_insuree.photo.filename:
             # HOST is taken from global variable used in the docker initialization
-            abs_url = GeneralConfiguration.get_host_domain().split('http://')[1]
+            # If URL root is not explicitly given in the settings 'localhost' is used
+            # (if value is empty validation exception is raised).
+            abs_url = GeneralConfiguration.get_host_domain().split('http://')[1] or 'localhost'
             domain = abs_url
             photo_uri = cls.__build_photo_uri(imis_insuree)
             photo = Attachment.construct()

--- a/api_fhir_r4/tests/mixin/patientTestMixin.py
+++ b/api_fhir_r4/tests/mixin/patientTestMixin.py
@@ -33,7 +33,7 @@ class PatientTestMixin(GenericTestMixin):
     _TEST_DOB = "1990-03-24"
     _TEST_ID = 10000
     _TEST_UUID = "0a60f36c-62eb-11ea-bb93-93ec0339a3dd"
-    _TEST_CHF_ID = "TEST_CHF_ID"
+    _TEST_CHF_ID = "827192671"
     _TEST_PASSPORT = "TEST_PASSPORT"
     _TEST_GENDER_CODE = "M"
     _TEST_GENDER = None

--- a/api_fhir_r4/tests/test/test_patient.json
+++ b/api_fhir_r4/tests/test/test_patient.json
@@ -103,7 +103,7 @@
             ]
          },
          "use":"usual",
-         "value":"TEST_CHF_ID"
+         "value":"827192671"
       }
    ],
    "maritalStatus":{

--- a/api_fhir_r4/tests/test_api_patient.py
+++ b/api_fhir_r4/tests/test_api_patient.py
@@ -170,11 +170,10 @@ class PatientAPITests(GenericFhirAPITestMixin, FhirApiReadTestMixin, APITestCase
         modified_payload = self.update_payload_missing_chfid_identifier(data=self._test_request_data)
         response = self.client.post(self.base_url, data=modified_payload, format='json', **headers)
         response_json = response.json()
-        splited_output = response_json["issue"][0]["details"]["text"].split(" ")
-        self.assertEqual(
-            splited_output[2] + " " + splited_output[3],
-            _("without code")
-        )
+        output_error_details = response_json["issue"][0]
+        self.assertTrue(response.status_code, 500)
+        self.assertTrue('details' in output_error_details.keys())
+        self.assertEqual(output_error_details['severity'], 'error')
 
     def test_post_should_raise_error_no_extensions(self):
         self.login()


### PR DESCRIPTION
Developed as part of [OAI-61](https://openimis.atlassian.net/jira/software/c/projects/OAI/boards/28?modal=detail&selectedIssue=OAI-61). Local instance of api_fhir_r4 module failed to create contained resource for claim due to invalid photo url. 