### PR TITLE
OE0-95: Fix the mocking context leaking into other tests

### DIFF
--- a/api_fhir_r4/tests/mixin/__init__.py
+++ b/api_fhir_r4/tests/mixin/__init__.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+from django.test import TestCase
 
 
 class FhirConverterTestMixin(TestCase):

--- a/api_fhir_r4/tests/mixin/invoiceTestMixin.py
+++ b/api_fhir_r4/tests/mixin/invoiceTestMixin.py
@@ -1,22 +1,17 @@
-from unittest import mock
-
 from django.contrib.contenttypes.models import ContentType
-from policy.models import Policy
+from fhir.resources.invoice import Invoice as FHIRInvoice
 
 from api_fhir_r4.configurations import R4IdentifierConfig
 from api_fhir_r4.tests import GenericTestMixin
 from api_fhir_r4.tests.mixin import FhirConverterTestMixin
+from api_fhir_r4.utils.timeUtils import TimeUtils
 from insuree.models import Family
 from invoice.models import Invoice, InvoiceLineItem
-from fhir.resources.invoice import Invoice as FHIRInvoice
-from api_fhir_r4.utils.timeUtils import TimeUtils
 
 
 class InvoiceTestMixin(GenericTestMixin, FhirConverterTestMixin):
     _TEST_INVOICE_STATUS = 'active'
-    _TEST_INVOICE_UUID = '12345678-1234-1234-1234-123456789012'
     _TEST_INVOICE_CODE = 'TEST-CODE'
-    _TEST_INVOICE_SUBJECT_TYPE = ContentType.objects.get(model='Family')
     _TEST_INVOICE_SUBJECT_TYPE_CODING = 'contribution'
     _TEST_INVOICE_THIRD_PARTY = Family()
     _TEST_INVOICE_THIRD_PARTY_UUID = '98765432-1234-1234-1234-123456789012'
@@ -24,7 +19,6 @@ class InvoiceTestMixin(GenericTestMixin, FhirConverterTestMixin):
     _TEST_INVOICE_TOTAL_NET = 10000.0
     _TEST_INVOICE_TOTAL_GROSS = 10000.0
     _TEST_INVOICE_CURRENCY = 'USD'
-    _TEST_LINE_ITEM_CHARGE_ITEM = ContentType.objects.get(model='Policy')
     _TEST_LINE_ITEM_CHARGE_ITEM_CODING = 'policy'
     _TEST_LiNE_ITEM_QUANTITY = 2
     _TEST_LINE_ITEM_UNIT_PRICE = 5000.0
@@ -35,11 +29,12 @@ class InvoiceTestMixin(GenericTestMixin, FhirConverterTestMixin):
     _TEST_LINE_ITEM_DEDUCTION = 100
     _TEST_LINE_ITEM_DEDUCTION_FACTOR = 1
     _TEST_LINE_ITEM_TAX_PRICE_COMPONENT_TYPE = 'tax'
-    _TEST_LINE_ITEM_TAX_RATE = 0.02
 
     def create_test_imis_instance(self):
+        self._TEST_INVOICE_SUBJECT_TYPE = ContentType.objects.get(model='Family')
+        self._TEST_LINE_ITEM_CHARGE_ITEM = ContentType.objects.get(model='Policy')
+
         imis_invoice = Invoice()
-        imis_invoice.uuid = self._TEST_INVOICE_UUID
         imis_invoice.code = self._TEST_INVOICE_CODE
         imis_invoice.subject_type = self._TEST_INVOICE_SUBJECT_TYPE
         imis_invoice.thirdparty = self._TEST_INVOICE_THIRD_PARTY
@@ -55,18 +50,9 @@ class InvoiceTestMixin(GenericTestMixin, FhirConverterTestMixin):
         imis_invoice_line_item.unit_price = self._TEST_LINE_ITEM_UNIT_PRICE
         imis_invoice_line_item.discount = self._TEST_LINE_ITEM_DISCOUNT
         imis_invoice_line_item.deduction = self._TEST_LINE_ITEM_DEDUCTION
-        imis_invoice_line_item.tax_rate = self._TEST_LINE_ITEM_TAX_RATE
+        imis_invoice_line_item.invoice = imis_invoice
 
-        with mock.patch('django.db.models.fields.related_descriptors.create_reverse_many_to_one_manager') as mock_patch:
-            class MockedManager(mock.MagicMock):
-                def all(self):
-                    return [imis_invoice_line_item]
-
-            mock_patch.return_value = MockedManager()
-            # noinspection PyStatementEffect,PyUnresolvedReferences
-            imis_invoice.line_items  # This call assigns mocked related manager to the model
-
-        return imis_invoice
+        return imis_invoice, imis_invoice_line_item
 
     def verify_imis_instance(self, imis_obj):
         raise NotImplementedError('verify_imis_instance() not implemented')
@@ -75,9 +61,12 @@ class InvoiceTestMixin(GenericTestMixin, FhirConverterTestMixin):
         raise NotImplementedError('create_test_fhir_instance() not implemented')
 
     def verify_fhir_instance(self, fhir_obj):
+        if not (hasattr(self, '_TEST_INVOICE_SUBJECT_TYPE') and hasattr(self, '_TEST_LINE_ITEM_CHARGE_ITEM')):
+            raise RuntimeError(
+                'To verify imis fhir instance first create imis instance with create_test_imis_instance()')
+
         self.assertIs(type(fhir_obj), FHIRInvoice)
         self.assertEqual(fhir_obj.status, self._TEST_INVOICE_STATUS)
-        self.verify_fhir_identifier(fhir_obj, R4IdentifierConfig.get_fhir_uuid_type_code(), self._TEST_INVOICE_UUID)
         self.verify_fhir_identifier(fhir_obj, R4IdentifierConfig.get_fhir_generic_type_code(), self._TEST_INVOICE_CODE)
         self.verify_fhir_coding_exists(fhir_obj.type.coding, self._TEST_INVOICE_SUBJECT_TYPE_CODING)
         self.assertTrue(self._TEST_INVOICE_THIRD_PARTY_UUID in fhir_obj.recipient.reference)
@@ -105,12 +94,6 @@ class InvoiceTestMixin(GenericTestMixin, FhirConverterTestMixin):
                 self.verify_price_component(price_component, self._TEST_LINE_ITEM_DEDUCTION_FACTOR,
                                             -self._TEST_LINE_ITEM_DEDUCTION,
                                             self._TEST_LINE_ITEM_DEDUCTION_PRICE_COMPONENT_TYPE)
-            elif price_component.type == self._TEST_LINE_ITEM_TAX_PRICE_COMPONENT_TYPE:
-                self.verify_price_component(price_component, self._TEST_LINE_ITEM_TAX_RATE,
-                                            ((self._TEST_LINE_ITEM_UNIT_PRICE * self._TEST_LiNE_ITEM_QUANTITY * (
-                                                    1 - self._TEST_LINE_ITEM_DISCOUNT))
-                                             - self._TEST_LINE_ITEM_DEDUCTION) * self._TEST_LINE_ITEM_TAX_RATE,
-                                            self._TEST_LINE_ITEM_TAX_PRICE_COMPONENT_TYPE)
 
     def verify_price_component(self, price_component, expected_factor, expected_amount, expected_type):
         self.assertGreater(len(price_component.extension), 0)

--- a/api_fhir_r4/tests/mixin/logInMixin.py
+++ b/api_fhir_r4/tests/mixin/logInMixin.py
@@ -1,0 +1,30 @@
+from api_fhir_r4.utils import DbManagerUtils
+from core.forms import User
+from core.services import create_or_update_interactive_user, create_or_update_core_user
+
+
+class LogInMixin:
+    _TEST_USER_NAME = "TestUserTest2"
+    _TEST_USER_PASSWORD = "TestPasswordTest2"
+    _TEST_DATA_USER = {
+        "username": _TEST_USER_NAME,
+        "last_name": _TEST_USER_NAME,
+        "password": _TEST_USER_PASSWORD,
+        "other_names": _TEST_USER_NAME,
+        "user_types": "INTERACTIVE",
+        "language": "en",
+        "roles": [9],
+    }
+
+    def get_or_create_user_api(self):
+        user = DbManagerUtils.get_object_or_none(User, username=self._TEST_USER_NAME)
+        if user is None:
+            user = self.__create_user_interactive_core()
+        return user
+
+    def __create_user_interactive_core(self):
+        i_user, i_user_created = create_or_update_interactive_user(
+            user_id=None, data=self._TEST_DATA_USER, audit_user_id=999, connected=False)
+        create_or_update_core_user(
+            user_uuid=None, username=self._TEST_DATA_USER["username"], i_user=i_user)
+        return DbManagerUtils.get_object_or_none(User, username=self._TEST_USER_NAME)

--- a/api_fhir_r4/tests/mixin/logInMixin.py
+++ b/api_fhir_r4/tests/mixin/logInMixin.py
@@ -13,7 +13,7 @@ class LogInMixin:
         "other_names": _TEST_USER_NAME,
         "user_types": "INTERACTIVE",
         "language": "en",
-        "roles": [9],
+        "roles": [1, 5, 9],
     }
 
     def get_or_create_user_api(self):

--- a/api_fhir_r4/tests/test_api_authorization.py
+++ b/api_fhir_r4/tests/test_api_authorization.py
@@ -1,34 +1,19 @@
 import json
 import os
 
-from core.models import User
-from core.services import create_or_update_interactive_user, create_or_update_core_user
-
 from rest_framework import status
 from rest_framework.test import APITestCase
-from api_fhir_r4.tests import GenericFhirAPITestMixin
-from api_fhir_r4.utils import DbManagerUtils
+
 from api_fhir_r4.configurations import GeneralConfiguration
+from api_fhir_r4.tests import GenericFhirAPITestMixin
+from api_fhir_r4.tests.mixin.logInMixin import LogInMixin
 
 
-class AuthorizationAPITests(GenericFhirAPITestMixin, APITestCase):
+class AuthorizationAPITests(GenericFhirAPITestMixin, APITestCase, LogInMixin):
     base_url = GeneralConfiguration.get_base_url()
     url_to_test_authorization = base_url + 'Group/'
-
     _test_json_path = "/test/test_login.json"
     _test_json_path_credentials = "/tests/test/test_login.json"
-    _TEST_EXPECTED_NAME = "UPDATED_NAME"
-    _TEST_USER_NAME = "TestUserTest2"
-    _TEST_USER_PASSWORD = "TestPasswordTest2"
-    _TEST_DATA_USER = {
-        "username": _TEST_USER_NAME,
-        "last_name": _TEST_USER_NAME,
-        "password": _TEST_USER_PASSWORD,
-        "other_names": _TEST_USER_NAME,
-        "user_types": "INTERACTIVE",
-        "language": "en",
-        "roles": [9],
-    }
     _test_request_data_credentials = None
 
     def setUp(self):
@@ -38,21 +23,8 @@ class AuthorizationAPITests(GenericFhirAPITestMixin, APITestCase):
         self._test_request_data_credentials = json.loads(json_representation)
         self.get_or_create_user_api()
 
-    def get_or_create_user_api(self):
-        user = DbManagerUtils.get_object_or_none(User, username=self._TEST_USER_NAME)
-        if user is None:
-            user = self.__create_user_interactive_core()
-        return user
-
     def get_bundle_from_json_response(self, response):
         pass
-
-    def __create_user_interactive_core(self):
-        i_user, i_user_created = create_or_update_interactive_user(
-            user_id=None, data=self._TEST_DATA_USER, audit_user_id=999, connected=False)
-        create_or_update_core_user(
-            user_uuid=None, username=self._TEST_DATA_USER["username"], i_user=i_user)
-        return DbManagerUtils.get_object_or_none(User, username=self._TEST_USER_NAME)
 
     def test_post_should_authorize_correctly(self):
         response = self.client.post(self.base_url + 'login/', data=self._test_request_data_credentials, format='json')

--- a/api_fhir_r4/tests/test_api_claim.py
+++ b/api_fhir_r4/tests/test_api_claim.py
@@ -1,26 +1,23 @@
 import json
 import os
 
-from rest_framework.test import APITestCase
 from rest_framework import status
-from core.models import User
-from core.services import create_or_update_interactive_user, create_or_update_core_user
-from api_fhir_r4.tests import GenericFhirAPITestMixin
+from rest_framework.test import APITestCase
+
 from api_fhir_r4.configurations import GeneralConfiguration
+from api_fhir_r4.tests import GenericFhirAPITestMixin
 from api_fhir_r4.tests import LocationTestMixin, ClaimAdminPractitionerTestMixin
-from api_fhir_r4.utils import DbManagerUtils, TimeUtils
+from api_fhir_r4.tests.mixin.logInMixin import LogInMixin
+from api_fhir_r4.utils import TimeUtils
 from claim.models import Claim
 from insuree.test_helpers import create_test_insuree
 from location.models import HealthFacility, UserDistrict
 from medical.models import Diagnosis
-
-
 from medical.test_helpers import create_test_item, create_test_service
 
 
-class ClaimAPITests(GenericFhirAPITestMixin, APITestCase):
-
-    base_url = GeneralConfiguration.get_base_url()+'Claim/'
+class ClaimAPITests(GenericFhirAPITestMixin, APITestCase, LogInMixin):
+    base_url = GeneralConfiguration.get_base_url() + 'Claim/'
     _test_json_path = "/test/test_claim.json"
 
     # diagnosis data
@@ -61,17 +58,6 @@ class ClaimAPITests(GenericFhirAPITestMixin, APITestCase):
     _ADMIN_AUDIT_USER_ID = -1
 
     _test_json_path_credentials = "/tests/test/test_login.json"
-    _TEST_USER_NAME = "TestUserTest2"
-    _TEST_USER_PASSWORD = "TestPasswordTest2"
-    _TEST_DATA_USER = {
-        "username": _TEST_USER_NAME,
-        "last_name": _TEST_USER_NAME,
-        "password": _TEST_USER_PASSWORD,
-        "other_names": _TEST_USER_NAME,
-        "user_types": "INTERACTIVE",
-        "language": "en",
-        "roles": [9],
-    }
     _test_request_data_credentials = None
 
     def setUp(self):
@@ -81,21 +67,6 @@ class ClaimAPITests(GenericFhirAPITestMixin, APITestCase):
         self._test_request_data_credentials = json.loads(json_representation)
         self._TEST_USER = self.get_or_create_user_api()
         self.create_dependencies()
-
-    def get_or_create_user_api(self):
-        user = DbManagerUtils.get_object_or_none(User, username=self._TEST_USER_NAME)
-        if user is None:
-            user = self.__create_user_interactive_core()
-        return user
-
-    def __create_user_interactive_core(self):
-        i_user, i_user_created = create_or_update_interactive_user(
-            user_id=None, data=self._TEST_DATA_USER, audit_user_id=999, connected=False
-        )
-        create_or_update_core_user(
-            user_uuid=None, username=self._TEST_DATA_USER["username"], i_user=i_user
-        )
-        return DbManagerUtils.get_object_or_none(User, username=self._TEST_USER_NAME)
 
     def create_dependencies(self):
         self._TEST_DIAGNOSIS_CODE = Diagnosis()
@@ -197,5 +168,6 @@ class ClaimAPITests(GenericFhirAPITestMixin, APITestCase):
             "Content-Type": "application/json",
             "HTTP_AUTHORIZATION": f"Bearer {token}"
         }
-        response = self.client.get(GeneralConfiguration.get_base_url() + 'ClaimResponse/', data=None, format='json', **headers)
+        response = self.client.get(GeneralConfiguration.get_base_url() + 'ClaimResponse/', data=None, format='json',
+                                   **headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/api_fhir_r4/tests/test_api_communication.py
+++ b/api_fhir_r4/tests/test_api_communication.py
@@ -1,41 +1,28 @@
 import json
 import os
 
-from api_fhir_r4.utils import DbManagerUtils
-from rest_framework.test import APITestCase
 from rest_framework import status
-from core.models import User
-from core.services import create_or_update_interactive_user, create_or_update_core_user
-from api_fhir_r4.tests import GenericFhirAPITestMixin
+from rest_framework.test import APITestCase
+
 from api_fhir_r4.configurations import GeneralConfiguration, R4CommunicationRequestConfig as Config
+from api_fhir_r4.tests import GenericFhirAPITestMixin
 from api_fhir_r4.tests import LocationTestMixin
+from api_fhir_r4.tests.mixin.logInMixin import LogInMixin
 from api_fhir_r4.utils import TimeUtils
-from claim.models import Claim, ClaimItem, ClaimService, Feedback
+from claim.models import Claim, ClaimItem, ClaimService
 from claim.test_helpers import create_test_claim_admin
 from core import datetime
-from location.models import HealthFacility
 from insuree.test_helpers import create_test_insuree
-from medical.test_helpers import create_test_item, create_test_service
+from location.models import HealthFacility
 from medical.models import Diagnosis
+from medical.test_helpers import create_test_item, create_test_service
 
 
-class CommunicationAPITests(GenericFhirAPITestMixin, APITestCase):
-
-    base_url = GeneralConfiguration.get_base_url()+'Communication/'
+class CommunicationAPITests(GenericFhirAPITestMixin, APITestCase, LogInMixin):
+    base_url = GeneralConfiguration.get_base_url() + 'Communication/'
     _test_json_path = "/test/test_communication.json"
 
     _test_json_path_credentials = "/tests/test/test_login.json"
-    _TEST_USER_NAME = "TestUserTest2"
-    _TEST_USER_PASSWORD = "TestPasswordTest2"
-    _TEST_DATA_USER = {
-        "username": _TEST_USER_NAME,
-        "last_name": _TEST_USER_NAME,
-        "password": _TEST_USER_PASSWORD,
-        "other_names": _TEST_USER_NAME,
-        "user_types": "INTERACTIVE",
-        "language": "en",
-        "roles": [5],
-    }
     _test_request_data_credentials = None
 
     # feedback expected data
@@ -192,19 +179,6 @@ class CommunicationAPITests(GenericFhirAPITestMixin, APITestCase):
         imis_claim.feedback_status = Claim.FEEDBACK_SELECTED
         imis_claim.save()
         return imis_claim
-
-    def get_or_create_user_api(self):
-        user = DbManagerUtils.get_object_or_none(User, username=self._TEST_USER_NAME)
-        if user is None:
-            user = self.__create_user_interactive_core()
-        return user
-
-    def __create_user_interactive_core(self):
-        i_user, i_user_created = create_or_update_interactive_user(
-            user_id=None, data=self._TEST_DATA_USER, audit_user_id=999, connected=False)
-        create_or_update_core_user(
-            user_uuid=None, username=self._TEST_DATA_USER["username"], i_user=i_user)
-        return DbManagerUtils.get_object_or_none(User, username=self._TEST_USER_NAME)
 
     def create_dependencies(self):
         self._TEST_CLAIM = self.create_test_claim()

--- a/api_fhir_r4/tests/test_api_communicationRequest.py
+++ b/api_fhir_r4/tests/test_api_communicationRequest.py
@@ -1,32 +1,19 @@
 import json
 import os
 
-from api_fhir_r4.tests import GenericFhirAPITestMixin
-from api_fhir_r4.configurations import GeneralConfiguration
-from core.models import User
-from core.services import create_or_update_interactive_user, create_or_update_core_user
 from rest_framework import status
 from rest_framework.test import APITestCase
-from api_fhir_r4.utils import DbManagerUtils
+
+from api_fhir_r4.configurations import GeneralConfiguration
+from api_fhir_r4.tests import GenericFhirAPITestMixin
+from api_fhir_r4.tests.mixin.logInMixin import LogInMixin
 
 
-class CommunicationRequestAPITests(GenericFhirAPITestMixin, APITestCase):
-
-    base_url = GeneralConfiguration.get_base_url()+'CommunicationRequest/'
+class CommunicationRequestAPITests(GenericFhirAPITestMixin, APITestCase, LogInMixin):
+    base_url = GeneralConfiguration.get_base_url() + 'CommunicationRequest/'
     _test_json_path = "/test/test_communicationRequest.json"
 
     _test_json_path_credentials = "/tests/test/test_login.json"
-    _TEST_USER_NAME = "TestUserTest2"
-    _TEST_USER_PASSWORD = "TestPasswordTest2"
-    _TEST_DATA_USER = {
-        "username": _TEST_USER_NAME,
-        "last_name": _TEST_USER_NAME,
-        "password": _TEST_USER_PASSWORD,
-        "other_names": _TEST_USER_NAME,
-        "user_types": "INTERACTIVE",
-        "language": "en",
-        "roles": [5],
-    }
     _test_request_data_credentials = None
 
     def setUp(self):
@@ -35,22 +22,6 @@ class CommunicationRequestAPITests(GenericFhirAPITestMixin, APITestCase):
         json_representation = open(dir_path + self._test_json_path_credentials).read()
         self._test_request_data_credentials = json.loads(json_representation)
         self._TEST_USER = self.get_or_create_user_api()
-
-
-    def get_or_create_user_api(self):
-        user = DbManagerUtils.get_object_or_none(User, username=self._TEST_USER_NAME)
-        if user is None:
-            user = self.__create_user_interactive_core()
-        return user
-
-    def __create_user_interactive_core(self):
-        i_user, i_user_created = create_or_update_interactive_user(
-            user_id=None, data=self._TEST_DATA_USER, audit_user_id=999, connected=False
-        )
-        create_or_update_core_user(
-            user_uuid=None, username=self._TEST_DATA_USER["username"], i_user=i_user
-        )
-        return DbManagerUtils.get_object_or_none(User, username=self._TEST_USER_NAME)
 
     def test_get_should_return_200(self):
         # test if return 200

--- a/api_fhir_r4/tests/test_api_contract.py
+++ b/api_fhir_r4/tests/test_api_contract.py
@@ -1,6 +1,7 @@
 import json
 import os
 
+from api_fhir_r4.tests.mixin.logInMixin import LogInMixin
 from api_fhir_r4.utils import DbManagerUtils
 from rest_framework.test import APITestCase
 from rest_framework import status
@@ -13,7 +14,7 @@ from insuree.test_helpers import create_test_insuree
 from product.test_helpers import create_test_product
 
 
-class ContractAPITests(GenericFhirAPITestMixin, APITestCase):
+class ContractAPITests(GenericFhirAPITestMixin, APITestCase, LogInMixin):
 
     base_url = GeneralConfiguration.get_base_url()+'Contract/'
     _test_json_path = "/test/test_contract.json"
@@ -25,17 +26,6 @@ class ContractAPITests(GenericFhirAPITestMixin, APITestCase):
     _TEST_PRODUCT_UUID = "8ed8d2d9-2644-4d29-ba37-ab772386cfca"
 
     _test_json_path_credentials = "/tests/test/test_login.json"
-    _TEST_USER_NAME = "TestUserTest2"
-    _TEST_USER_PASSWORD = "TestPasswordTest2"
-    _TEST_DATA_USER = {
-        "username": _TEST_USER_NAME,
-        "last_name": _TEST_USER_NAME,
-        "password": _TEST_USER_PASSWORD,
-        "other_names": _TEST_USER_NAME,
-        "user_types": "INTERACTIVE",
-        "language": "en",
-        "roles": [1],
-    }
     _test_request_data_credentials = None
 
     def setUp(self):
@@ -44,19 +34,6 @@ class ContractAPITests(GenericFhirAPITestMixin, APITestCase):
         json_representation = open(dir_path + self._test_json_path_credentials).read()
         self._test_request_data_credentials = json.loads(json_representation)
         self.get_or_create_user_api()
-
-    def get_or_create_user_api(self):
-        user = DbManagerUtils.get_object_or_none(User, username=self._TEST_USER_NAME)
-        if user is None:
-            user = self.__create_user_interactive_core()
-        return user
-
-    def __create_user_interactive_core(self):
-        i_user, i_user_created = create_or_update_interactive_user(
-            user_id=None, data=self._TEST_DATA_USER, audit_user_id=999, connected=False)
-        create_or_update_core_user(
-            user_uuid=None, username=self._TEST_DATA_USER["username"], i_user=i_user)
-        return DbManagerUtils.get_object_or_none(User, username=self._TEST_USER_NAME)
 
     def create_dependencies(self):
         # create mocked insuree

--- a/api_fhir_r4/tests/test_api_group.py
+++ b/api_fhir_r4/tests/test_api_group.py
@@ -2,21 +2,18 @@ import json
 import os
 
 from django.utils.translation import gettext as _
-from api_fhir_r4.utils import DbManagerUtils
-from insuree.test_helpers import *
-from rest_framework.test import APITestCase
-from rest_framework import status
 from fhir.resources.group import Group
+from rest_framework import status
+from rest_framework.test import APITestCase
 
-from api_fhir_r4.tests import GenericFhirAPITestMixin, FhirApiReadTestMixin, GroupTestMixin
 from api_fhir_r4.configurations import GeneralConfiguration
-from core.models import User
-from core.services import create_or_update_interactive_user, create_or_update_core_user
+from api_fhir_r4.tests import GenericFhirAPITestMixin, FhirApiReadTestMixin, GroupTestMixin
+from api_fhir_r4.tests.mixin.logInMixin import LogInMixin
+from insuree.test_helpers import *
 
 
-class GroupAPITests(GenericFhirAPITestMixin, FhirApiReadTestMixin, APITestCase):
-
-    base_url = GeneralConfiguration.get_base_url()+'Group/'
+class GroupAPITests(GenericFhirAPITestMixin, FhirApiReadTestMixin, APITestCase, LogInMixin):
+    base_url = GeneralConfiguration.get_base_url() + 'Group/'
     _test_json_path = "/test/test_group.json"
     _TEST_INSUREE_CHFID = "TestChfId1"
     _TEST_INSUREE_LAST_NAME = "Test"
@@ -25,17 +22,6 @@ class GroupAPITests(GenericFhirAPITestMixin, FhirApiReadTestMixin, APITestCase):
     _TEST_INSUREE_CHFID_NOT_EXIST = "NotExistedCHF"
 
     _test_json_path_credentials = "/tests/test/test_login.json"
-    _TEST_USER_NAME = "TestUserTest2"
-    _TEST_USER_PASSWORD = "TestPasswordTest2"
-    _TEST_DATA_USER = {
-        "username": _TEST_USER_NAME,
-        "last_name": _TEST_USER_NAME,
-        "password": _TEST_USER_PASSWORD,
-        "other_names": _TEST_USER_NAME,
-        "user_types": "INTERACTIVE",
-        "language": "en",
-        "roles": [1],
-    }
     _test_request_data_credentials = None
 
     def setUp(self):
@@ -44,19 +30,6 @@ class GroupAPITests(GenericFhirAPITestMixin, FhirApiReadTestMixin, APITestCase):
         json_representation = open(dir_path + self._test_json_path_credentials).read()
         self._test_request_data_credentials = json.loads(json_representation)
         self.get_or_create_user_api()
-
-    def get_or_create_user_api(self):
-        user = DbManagerUtils.get_object_or_none(User, username=self._TEST_USER_NAME)
-        if user is None:
-            user = self.__create_user_interactive_core()
-        return user
-
-    def __create_user_interactive_core(self):
-        i_user, i_user_created = create_or_update_interactive_user(
-            user_id=None, data=self._TEST_DATA_USER, audit_user_id=999, connected=False)
-        create_or_update_core_user(
-            user_uuid=None, username=self._TEST_DATA_USER["username"], i_user=i_user)
-        return DbManagerUtils.get_object_or_none(User, username=self._TEST_USER_NAME)
 
     def verify_updated_obj(self, updated_obj):
         self.assertTrue(isinstance(updated_obj, Group))

--- a/api_fhir_r4/tests/test_api_invoice.py
+++ b/api_fhir_r4/tests/test_api_invoice.py
@@ -1,11 +1,25 @@
-from api_fhir_r4.configurations import GeneralConfiguration
-from api_fhir_r4.tests import GenericFhirAPITestMixin, FhirApiReadTestMixin
 from rest_framework.test import APITestCase
 
+from api_fhir_r4.configurations import GeneralConfiguration
+from api_fhir_r4.tests import GenericFhirAPITestMixin, FhirApiReadTestMixin
+from api_fhir_r4.tests.mixin.invoiceTestMixin import InvoiceTestMixin
+from api_fhir_r4.tests.mixin.logInMixin import LogInMixin
+from insuree.models import Insuree
 
-class InvoiceAPITests(GenericFhirAPITestMixin, FhirApiReadTestMixin, APITestCase):
+
+class InvoiceAPITests(GenericFhirAPITestMixin, FhirApiReadTestMixin, APITestCase, LogInMixin, InvoiceTestMixin):
     base_url = GeneralConfiguration.get_base_url() + 'Invoice/?resourceType=invoice'
     _test_json_path = "/test/test_invoice.json"
 
     def setUp(self):
         super(InvoiceAPITests, self).setUp()
+        user = self.get_or_create_user_api()
+        self.imis_invoice, self.imis_invoice_line_item = self.create_test_imis_instance()
+        self.imis_invoice.thirdparty = Insuree.objects.first()
+        self.imis_invoice.save(username=user.username)
+        self.imis_invoice_line_item.save(username=user.username)
+
+    def tearDown(self):
+        user = self.get_or_create_user_api()
+        self.imis_invoice_line_item.delete(username=user.username)
+        self.imis_invoice.delete(username=user.username)

--- a/api_fhir_r4/tests/test_api_login.py
+++ b/api_fhir_r4/tests/test_api_login.py
@@ -1,34 +1,20 @@
 import json
 import os
 
-from core.models import User
-from core.services import create_or_update_interactive_user, create_or_update_core_user
-
 from rest_framework import status
 from rest_framework.test import APITestCase
+
+from api_fhir_r4.configurations import GeneralConfiguration
 from api_fhir_r4.tests import GenericFhirAPITestMixin, FhirApiCreateTestMixin
-from api_fhir_r4.utils import DbManagerUtils
-from api_fhir_r4.configurations import  GeneralConfiguration
+from api_fhir_r4.tests.mixin.logInMixin import LogInMixin
 
 
-class LoginAPITests(GenericFhirAPITestMixin, FhirApiCreateTestMixin, APITestCase):
-
-    base_url = GeneralConfiguration.get_base_url()+'login/'
+class LoginAPITests(GenericFhirAPITestMixin, FhirApiCreateTestMixin, APITestCase, LogInMixin):
+    base_url = GeneralConfiguration.get_base_url() + 'login/'
     _test_json_path = "/test/test_login.json"
     _test_json_path_wrong_credentials = "/tests/test/test_login_bad_credentials.json"
     _test_json_path_wrong_payload = "/tests/test/test_login_bad_payload.json"
     _TEST_EXPECTED_NAME = "UPDATED_NAME"
-    _TEST_USER_NAME = "TestUserTest2"
-    _TEST_USER_PASSWORD = "TestPasswordTest2"
-    _TEST_DATA_USER = {
-        "username": _TEST_USER_NAME,
-        "last_name": _TEST_USER_NAME,
-        "password": _TEST_USER_PASSWORD,
-        "other_names": _TEST_USER_NAME,
-        "user_types": "INTERACTIVE",
-        "language": "en",
-        "roles": [9],
-    }
     _test_request_data_wrong_credentials = None
     _test_request_data_bad_payload = None
 
@@ -40,21 +26,8 @@ class LoginAPITests(GenericFhirAPITestMixin, FhirApiCreateTestMixin, APITestCase
         json_representation = open(dir_path + self._test_json_path_wrong_payload).read()
         self._test_request_data_bad_payload = json.loads(json_representation)
 
-    def get_or_create_user_api(self):
-        user = DbManagerUtils.get_object_or_none(User, username=self._TEST_USER_NAME)
-        if user is None:
-            user = self.__create_user_interactive_core()
-        return user
-
     def get_bundle_from_json_response(self, response):
         pass
-
-    def __create_user_interactive_core(self):
-        i_user, i_user_created = create_or_update_interactive_user(
-            user_id=None, data=self._TEST_DATA_USER, audit_user_id=999, connected=False)
-        create_or_update_core_user(
-            user_uuid=None, username=self._TEST_DATA_USER["username"], i_user=i_user)
-        return DbManagerUtils.get_object_or_none(User, username=self._TEST_USER_NAME)
 
     def test_post_should_create_correctly(self):
         self.get_or_create_user_api()

--- a/api_fhir_r4/tests/test_invoiceConverter.py
+++ b/api_fhir_r4/tests/test_invoiceConverter.py
@@ -1,11 +1,12 @@
-import json
 import os
 
 from api_fhir_r4.converters import InvoiceConverter
 from api_fhir_r4.tests.mixin.invoiceTestMixin import InvoiceTestMixin
+from api_fhir_r4.tests.mixin.logInMixin import LogInMixin
 
 
-class InvoiceConverterTestCase(InvoiceTestMixin):
+class InvoiceConverterTestCase(InvoiceTestMixin, LogInMixin):
+    _TEST_USER_NAME = "TestUserTest2"
     __TEST_INVOICE_JSON_PATH = "/test/test_invoice.json"
 
     @classmethod
@@ -18,9 +19,14 @@ class InvoiceConverterTestCase(InvoiceTestMixin):
         super(InvoiceConverterTestCase, self).setUp()
 
     def test_to_fhir_obj(self):
-        imis_invoice = self.create_test_imis_instance()
+        user = self.get_or_create_user_api()
+        imis_invoice, imis_invoice_line_item = self.create_test_imis_instance()
+        imis_invoice.save(username=user.username)
+        imis_invoice_line_item.save(username=user.username)
         fhir_invoice = InvoiceConverter.to_fhir_obj(imis_invoice)
         self.verify_fhir_instance(fhir_invoice)
+        imis_invoice_line_item.delete(username=user.username)
+        imis_invoice.delete(username=user.username)
 
     def test_to_imis_obj(self):
         self.assertRaises(NotImplementedError, InvoiceConverter.to_imis_obj, object(), 1)


### PR DESCRIPTION
[https://openimis.atlassian.net/browse/OE0-95](https://openimis.atlassian.net/browse/OE0-95)

Changes:
- Replaced mocking of `Invoice.line_items` with saving a model for the test and removing it after
- Moved log in helper methods from `test_api_login` to separate mixin to reuse in other api tests
- Fixed wrong import in `FhirConverterTestMixin`
- Cleaned repeating "create user" code from api tests