### PR TITLE
OPL-58: Add authorization to Subscription endpoints (owner/permissions)

### DIFF
--- a/api_fhir_r4/configurations/R4SubscriptionConfig.py
+++ b/api_fhir_r4/configurations/R4SubscriptionConfig.py
@@ -9,6 +9,22 @@ class R4SubscriptionConfig(SubscriptionConfiguration):
         cls.get_config().R4_fhir_subscription_config = cfg['R4_fhir_subscription_config']
 
     @classmethod
+    def get_fhir_sub_search_perms(cls):
+        return cls.get_config_attribute('R4_fhir_subscription_config').get('get_fhir_sub_search_perms', ['158001'])
+
+    @classmethod
+    def get_fhir_sub_create_perms(cls):
+        return cls.get_config_attribute('R4_fhir_subscription_config').get('fhir_sub_create_perms', ['158002'])
+
+    @classmethod
+    def get_fhir_sub_update_perms(cls):
+        return cls.get_config_attribute('R4_fhir_subscription_config').get('get_fhir_sub_update_perms', ['158003'])
+
+    @classmethod
+    def get_fhir_sub_delete_perms(cls):
+        return cls.get_config_attribute('R4_fhir_subscription_config').get('get_fhir_sub_delete_perms', ['158004'])
+
+    @classmethod
     def get_fhir_subscription_channel_rest_hook(cls):
         return cls.get_config_attribute('R4_fhir_subscription_config').get('fhir_sub_channel_rest_hook', 'rest_hook')
 

--- a/api_fhir_r4/configurations/__init__.py
+++ b/api_fhir_r4/configurations/__init__.py
@@ -520,6 +520,22 @@ class SubscriptionConfiguration(BaseConfiguration):
         raise NotImplementedError('`build_configuration()` must be implemented.')
 
     @classmethod
+    def get_fhir_sub_search_perms(cls):
+        raise NotImplementedError('`get_fhir_sub_search_perms()` must be implemented.')
+
+    @classmethod
+    def get_fhir_sub_create_perms(cls):
+        raise NotImplementedError('`get_fhir_sub_create_perms()` must be implemented.')
+
+    @classmethod
+    def get_fhir_sub_update_perms(cls):
+        raise NotImplementedError('`get_fhir_sub_update_perms()` must be implemented.')
+
+    @classmethod
+    def get_fhir_sub_delete_perms(cls):
+        raise NotImplementedError('`get_fhir_sub_delete_perms()` must be implemented.')
+
+    @classmethod
     def get_fhir_subscription_channel_rest_hook(cls):
         raise NotImplementedError('`get_fhir_subscription_channel_rest_hook()` must be implemented.')
 

--- a/api_fhir_r4/converters/subscriptionConverter.py
+++ b/api_fhir_r4/converters/subscriptionConverter.py
@@ -69,7 +69,10 @@ class SubscriptionConverter(BaseFHIRConverter):
         criteria = deepcopy(imis_subscription.criteria)
         resource = criteria.pop('resource_type')
         arguments = '&'.join(f'{key}={value}' for key, value in criteria.items())
-        fhir_subscription['criteria'] = f'{resource}/?{arguments}'
+        if len(arguments) > 0:
+            fhir_subscription['criteria'] = f'{resource}/?{arguments}'
+        else:
+            fhir_subscription['criteria'] = f'{resource}/'
 
     @classmethod
     def _build_fhir_error(cls, fhir_subscription, imis_subscription):

--- a/api_fhir_r4/defaultConfig.py
+++ b/api_fhir_r4/defaultConfig.py
@@ -177,6 +177,10 @@ DEFAULT_CFG = {
         "fhir_bill_charge_item_system": "CodeSystem/bill-charge-item"
     },
     "R4_fhir_subscription_config": {
+        "fhir_sub_search_perms": ['158001'],
+        "fhir_sub_create_perms": ['158002'],
+        "fhir_sub_update_perms": ['158003'],
+        "fhir_sub_delete_perms": ['158004'],
         "fhir_sub_channel_rest_hook": "rest-hook",
         "fhir_sub_status_off": "off",
         "fhir_sub_status_active": "active"

--- a/api_fhir_r4/permissions.py
+++ b/api_fhir_r4/permissions.py
@@ -1,3 +1,4 @@
+from api_fhir_r4.configurations import R4SubscriptionConfig
 from claim.apps import ClaimConfig
 from insuree.apps import InsureeConfig
 from location.apps import LocationConfig
@@ -149,3 +150,11 @@ class FHIRApiInvoicePermissions(FHIRApiPermissions):
     permissions_put = InvoiceConfig.gql_invoice_update_perms
     permissions_patch = InvoiceConfig.gql_invoice_update_perms
     permissions_delete = InvoiceConfig.gql_invoice_delete_perms
+
+
+class FHIRApiSubscriptionPermissions(FHIRApiPermissions):
+    permissions_get = R4SubscriptionConfig.get_fhir_sub_search_perms()
+    permissions_post = R4SubscriptionConfig.get_fhir_sub_create_perms()
+    permissions_put = R4SubscriptionConfig.get_fhir_sub_update_perms()
+    permissions_patch = R4SubscriptionConfig.get_fhir_sub_update_perms()
+    permissions_delete = R4SubscriptionConfig.get_fhir_sub_delete_perms()

--- a/api_fhir_r4/serializers/subscriptionSerializer.py
+++ b/api_fhir_r4/serializers/subscriptionSerializer.py
@@ -1,7 +1,8 @@
 from copy import deepcopy
 
+from rest_framework.exceptions import ValidationError, APIException, PermissionDenied
+
 from api_fhir_r4.converters import SubscriptionConverter
-from api_fhir_r4.exceptions import FHIRException
 from api_fhir_r4.models import Subscription
 from api_fhir_r4.permissions import FHIRApiInsureePermissions, FHIRApiInvoicePermissions
 from api_fhir_r4.serializers import BaseFHIRSerializer
@@ -47,21 +48,21 @@ class SubscriptionSerializer(BaseFHIRSerializer):
         if result.get('success', False):
             return Subscription.objects.get(id=result['data']['id'])
         else:
-            raise FHIRException(self._error_while_saving % {'msg': result.get('message', 'Unknown')})
+            raise APIException(self._error_while_saving % {'msg': result.get('message', 'Unknown')})
 
     def check_resource_rights(self, user, data):
         resource_type = data.get('criteria', {}).get('resource_type', '').lower()
         if not resource_type or resource_type not in self.resource_permissions:
-            raise FHIRException(self._error_while_saving % {'msg': f'Invalid resource_type ({resource_type})'})
+            raise ValidationError(self._error_while_saving % {'msg': f'Invalid resource_type ({resource_type})'})
 
         if not user.has_perms(self.resource_permissions[resource_type]):
-            raise FHIRException(
-                self._error_while_saving % {'msg': f'You have no permissions to subscribe to {resource_type}'})
+            raise PermissionDenied(
+                detail=self._error_while_saving % {'msg': f'You have no permissions to subscribe to {resource_type}'})
 
     def check_object_owner(self, user, instance):
         if str(user.id).lower() != str(instance.user_created.id).lower():
-            raise FHIRException(self._error_while_saving % {'msg': 'You are not the owner of this subscription'})
+            raise APIException(self._error_while_saving % {'msg': 'You are not the owner of this subscription'})
 
     def check_instance_id(self, instance, validated_data):
         if validated_data['id'] and str(instance.id) != validated_data['id']:
-            raise FHIRException(self._error_while_saving % {'msg': 'Invalid ID in the payload'})
+            raise APIException(self._error_while_saving % {'msg': 'Invalid ID in the payload'})

--- a/api_fhir_r4/serializers/subscriptionSerializer.py
+++ b/api_fhir_r4/serializers/subscriptionSerializer.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from api_fhir_r4.converters import SubscriptionConverter
 from api_fhir_r4.exceptions import FHIRException
 from api_fhir_r4.models import Subscription
+from api_fhir_r4.permissions import FHIRApiInsureePermissions, FHIRApiInvoicePermissions
 from api_fhir_r4.serializers import BaseFHIRSerializer
 from api_fhir_r4.services import SubscriptionService
 from api_fhir_r4.utils import TimeUtils
@@ -10,6 +11,12 @@ from api_fhir_r4.utils import TimeUtils
 
 class SubscriptionSerializer(BaseFHIRSerializer):
     fhirConverter = SubscriptionConverter
+    _error_while_saving = 'Error while saving a subscription: %(msg)s'
+
+    resource_permissions = {
+        'patient': FHIRApiInsureePermissions.permissions_get,
+        'invoice': FHIRApiInvoicePermissions.permissions_get
+    }
 
     def to_internal_value(self, data):
         data['end'] = TimeUtils.str_iso_to_date(data['end'])
@@ -17,27 +24,44 @@ class SubscriptionSerializer(BaseFHIRSerializer):
 
     def create(self, validated_data):
         user = self.context['request'].user
+        self.check_resource_rights(user, validated_data)
         service = SubscriptionService(user)
         copied_data = deepcopy(validated_data)
         del copied_data['_state'], copied_data['_original_state']
         result = service.create(copied_data)
-        if result.get('success', False):
-            return Subscription.objects.get(id=result['data']['id'])
-        else:
-            msg = result.get('message', 'Unknown')
-            raise FHIRException(f'Error while creating a subscription: {msg}')
+        return self.get_result_object(result)
 
     def update(self, instance, validated_data):
-        if str(instance.id) != validated_data['id']:
-            raise FHIRException(f'Error while updating a subscription: You cannot change the instance ID')
-
         user = self.context['request'].user
+        self.check_instance_id(instance, validated_data)
+        self.check_object_owner(user, instance)
+        self.check_resource_rights(user, validated_data)
         service = SubscriptionService(user)
         copied_data = {key: value for key, value in deepcopy(validated_data).items() if value is not None}
+        copied_data['id'] = instance.id
         del copied_data['_state'], copied_data['_original_state']
         result = service.update(copied_data)
+        return self.get_result_object(result)
+
+    def get_result_object(self, result):
         if result.get('success', False):
             return Subscription.objects.get(id=result['data']['id'])
         else:
-            msg = result.get('message', 'Unknown')
-            raise FHIRException(f'Error while updating a subscription: {msg}')
+            raise FHIRException(self._error_while_saving % {'msg': result.get('message', 'Unknown')})
+
+    def check_resource_rights(self, user, data):
+        resource_type = data.get('criteria', {}).get('resource_type', '').lower()
+        if not resource_type or resource_type not in self.resource_permissions:
+            raise FHIRException(self._error_while_saving % {'msg': f'Invalid resource_type ({resource_type})'})
+
+        if not user.has_perms(self.resource_permissions[resource_type]):
+            raise FHIRException(
+                self._error_while_saving % {'msg': f'You have no permissions to subscribe to {resource_type}'})
+
+    def check_object_owner(self, user, instance):
+        if str(user.id).lower() != str(instance.user_created.id).lower():
+            raise FHIRException(self._error_while_saving % {'msg': 'You are not the owner of this subscription'})
+
+    def check_instance_id(self, instance, validated_data):
+        if validated_data['id'] and str(instance.id) != validated_data['id']:
+            raise FHIRException(self._error_while_saving % {'msg': 'Invalid ID in the payload'})

--- a/api_fhir_r4/services.py
+++ b/api_fhir_r4/services.py
@@ -1,10 +1,10 @@
 from api_fhir_r4.models import Subscription
+from api_fhir_r4.validation import SubscriptionValidation
 from core.services import BaseService
-from core.validation import BaseModelValidation
 
 
 class SubscriptionService(BaseService):
     OBJECT_TYPE = Subscription
 
-    def __init__(self, user, validation_class=BaseModelValidation):
+    def __init__(self, user, validation_class=SubscriptionValidation):
         super().__init__(user, validation_class)

--- a/api_fhir_r4/validation.py
+++ b/api_fhir_r4/validation.py
@@ -1,31 +1,20 @@
-from typing import Type
-
 from django.core.exceptions import ValidationError
 
 from api_fhir_r4.models import Subscription
-from core.models import HistoryModel
 from core.validation import BaseModelValidation
 
 
 class SubscriptionValidation(BaseModelValidation):
     OBJECT_TYPE = Subscription
 
-    allowed_resources = ('patient', 'invoice')
-
     @classmethod
     def validate_create(cls, user, **data):
-        cls.check_allowed_resources(**data)
+        super().validate_create(user, **data)
 
     @classmethod
     def validate_update(cls, user, **data):
-        cls.check_allowed_resources(**data)
+        super().validate_update(user, **data)
 
     @classmethod
     def validate_delete(cls, user, **data):
         super().validate_delete(user, **data)
-
-    @classmethod
-    def check_allowed_resources(cls, **data):
-        resource_type = data.get('criteria', {}).get('resource_type', '').lower()
-        if not resource_type or resource_type not in cls.allowed_resources:
-            raise ValidationError(f'Resource type not allowed: {resource_type}')

--- a/api_fhir_r4/validation.py
+++ b/api_fhir_r4/validation.py
@@ -1,0 +1,31 @@
+from typing import Type
+
+from django.core.exceptions import ValidationError
+
+from api_fhir_r4.models import Subscription
+from core.models import HistoryModel
+from core.validation import BaseModelValidation
+
+
+class SubscriptionValidation(BaseModelValidation):
+    OBJECT_TYPE = Subscription
+
+    allowed_resources = ('patient', 'invoice')
+
+    @classmethod
+    def validate_create(cls, user, **data):
+        cls.check_allowed_resources(**data)
+
+    @classmethod
+    def validate_update(cls, user, **data):
+        cls.check_allowed_resources(**data)
+
+    @classmethod
+    def validate_delete(cls, user, **data):
+        super().validate_delete(user, **data)
+
+    @classmethod
+    def check_allowed_resources(cls, **data):
+        resource_type = data.get('criteria', {}).get('resource_type', '').lower()
+        if not resource_type or resource_type not in cls.allowed_resources:
+            raise ValidationError(f'Resource type not allowed: {resource_type}')

--- a/api_fhir_r4/views/fhir/subscription.py
+++ b/api_fhir_r4/views/fhir/subscription.py
@@ -2,19 +2,31 @@ from rest_framework.viewsets import ModelViewSet
 
 from api_fhir_r4.exceptions import FHIRException
 from api_fhir_r4.models import Subscription
+from api_fhir_r4.permissions import FHIRApiSubscriptionPermissions
 from api_fhir_r4.serializers import SubscriptionSerializer
 from api_fhir_r4.services import SubscriptionService
 from api_fhir_r4.views.fhir.base import BaseFHIRView
 
 
 class SubscriptionViewSet(BaseFHIRView, ModelViewSet):
+    _error_while_saving = 'Error while saving a subscription: %(msg)s'
     serializer_class = SubscriptionSerializer
     queryset = Subscription.objects.filter(is_deleted=False).order_by('date_created')
     http_method_names = ('get', 'post', 'put', 'delete')
+    permission_classes = (FHIRApiSubscriptionPermissions,)
 
     def perform_destroy(self, instance):
+        self.check_object_owner(self.request.user, instance)
         service = SubscriptionService(self.request.user)
         result = service.delete({'id': instance.id})
+        self.check_error_message(result)
+
+    @staticmethod
+    def check_error_message(result):
         if not result.get('success', False):
             msg = result.get('message', 'Unknown')
             raise FHIRException(f'Error while deleting a subscription: {msg}')
+
+    def check_object_owner(self, user, instance):
+        if str(user.id).lower() != str(instance.user_created.id).lower():
+            raise FHIRException(self._error_while_saving % {'msg': 'You are not the owner of this subscription'})

--- a/api_fhir_r4/views/fhir/subscription.py
+++ b/api_fhir_r4/views/fhir/subscription.py
@@ -1,6 +1,6 @@
+from rest_framework.exceptions import PermissionDenied, APIException
 from rest_framework.viewsets import ModelViewSet
 
-from api_fhir_r4.exceptions import FHIRException
 from api_fhir_r4.models import Subscription
 from api_fhir_r4.permissions import FHIRApiSubscriptionPermissions
 from api_fhir_r4.serializers import SubscriptionSerializer
@@ -9,14 +9,16 @@ from api_fhir_r4.views.fhir.base import BaseFHIRView
 
 
 class SubscriptionViewSet(BaseFHIRView, ModelViewSet):
-    _error_while_saving = 'Error while saving a subscription: %(msg)s'
+    _error_while_deleting = 'Error while deleting a subscription: %(msg)s'
     serializer_class = SubscriptionSerializer
     queryset = Subscription.objects.filter(is_deleted=False).order_by('date_created')
     http_method_names = ('get', 'post', 'put', 'delete')
     permission_classes = (FHIRApiSubscriptionPermissions,)
 
     def perform_destroy(self, instance):
-        self.check_object_owner(self.request.user, instance)
+        if not self.check_if_owner(self.request.user, instance):
+            raise PermissionDenied(
+                detail=self._error_while_deleting % {'msg': 'You are not the owner of this subscription'})
         service = SubscriptionService(self.request.user)
         result = service.delete({'id': instance.id})
         self.check_error_message(result)
@@ -25,8 +27,9 @@ class SubscriptionViewSet(BaseFHIRView, ModelViewSet):
     def check_error_message(result):
         if not result.get('success', False):
             msg = result.get('message', 'Unknown')
-            raise FHIRException(f'Error while deleting a subscription: {msg}')
+            raise APIException(f'Error while deleting a subscription: {msg}')
 
-    def check_object_owner(self, user, instance):
-        if str(user.id).lower() != str(instance.user_created.id).lower():
-            raise FHIRException(self._error_while_saving % {'msg': 'You are not the owner of this subscription'})
+    @staticmethod
+    def check_if_owner(user, instance):
+        return str(user.id).lower() == str(instance.user_created.id).lower()
+


### PR DESCRIPTION
[https://openimis.atlassian.net/browse/OPL-58](https://openimis.atlassian.net/browse/OPL-58)
This PR depends on https://github.com/openimis/openimis-be-api_fhir_r4_py/pull/84

Changes:
- Added subscription permission group (CRUD) and assigned them to respective actions
- Added validation to resource requested by the subscription (Does the user have permissions to read the resources)