### PR TITLE
OPL-71 Move Insuree business logic from GQL mutations to services

### DIFF
--- a/api_fhir_r4/serializers/groupSerializer.py
+++ b/api_fhir_r4/serializers/groupSerializer.py
@@ -1,10 +1,10 @@
 import copy
 
 from insuree.models import Family, Insuree
-from insuree.gql_mutations import update_or_create_family
 from api_fhir_r4.converters import GroupConverter
 from api_fhir_r4.exceptions import FHIRException
 from api_fhir_r4.serializers import BaseFHIRSerializer
+from insuree.services import FamilyService
 
 
 class GroupSerializer(BaseFHIRSerializer):
@@ -21,7 +21,7 @@ class GroupSerializer(BaseFHIRSerializer):
         copied_data["head_insuree"] = insuree.__dict__
         copied_data["contribution"] = None
         del copied_data['_state']
-        new_family = update_or_create_family(copied_data, user)
+        new_family = FamilyService(user).create_or_update(copied_data)
         return new_family
 
     def update(self, instance, validated_data):
@@ -35,5 +35,5 @@ class GroupSerializer(BaseFHIRSerializer):
         validated_data["id"] = family.id
         validated_data["uuid"] = family.uuid
         del validated_data['_state']
-        instance = update_or_create_family(validated_data, user)
+        instance = FamilyService(user).create_or_update(validated_data)
         return instance

--- a/api_fhir_r4/serializers/patientSerializer.py
+++ b/api_fhir_r4/serializers/patientSerializer.py
@@ -1,12 +1,13 @@
 import copy
 
 from insuree.apps import InsureeConfig
-from insuree.models import Insuree, Gender, Education, Profession, Family, InsureePhoto
-from insuree.gql_mutations import update_or_create_insuree, create_file
+from insuree.models import Insuree, Family
+from insuree.gql_mutations import create_file
 
 from api_fhir_r4.converters import PatientConverter
 from api_fhir_r4.exceptions import FHIRException
 from api_fhir_r4.serializers import BaseFHIRSerializer
+from insuree.services import InsureeService
 
 
 class PatientSerializer(BaseFHIRSerializer):
@@ -21,7 +22,7 @@ class PatientSerializer(BaseFHIRSerializer):
         copied_data = copy.deepcopy(validated_data)
         if '_state' in validated_data:
             del copied_data['_state']
-        obj = update_or_create_insuree(copied_data, user)
+        obj = InsureeService(user).create_or_update(copied_data)
         # create photo as a file to specified configured path
         if InsureeConfig.insuree_photos_root_path:
             create_file(date=obj.photo.date, insuree_id=obj.id, photo_bin=obj.photo.photo)
@@ -40,5 +41,5 @@ class PatientSerializer(BaseFHIRSerializer):
         validated_data["id"] = insuree.id
         validated_data["uuid"] = insuree.uuid
         del validated_data['_state']
-        instance = update_or_create_insuree(validated_data, user)
+        instance = InsureeService(user).create_or_update(validated_data)
         return instance


### PR DESCRIPTION
[https://openimis.atlassian.net/browse/OPL-71](https://openimis.atlassian.net/browse/OPL-71)
This PR depends on https://github.com/openimis/openimis-be-insuree_py/pull/32

Changes:
- Adjusted serializers to use services instead of mutation code