### PR TITLE
OPL-72 Added tests for Subscription CRUD, Converter and Endpoint

### DIFF
--- a/api_fhir_r4/converters/subscriptionConverter.py
+++ b/api_fhir_r4/converters/subscriptionConverter.py
@@ -3,10 +3,11 @@ from urllib import parse
 
 from fhir.resources.subscription import Subscription as FHIRSubscription
 
-from api_fhir_r4.converters import BaseFHIRConverter
+from api_fhir_r4.converters import BaseFHIRConverter, ReferenceConverterMixin
 from api_fhir_r4.exceptions import FHIRException
 from api_fhir_r4.mapping.subscriptionMapping import SubscriptionChannelMapping, SubscriptionStatusMapping
 from api_fhir_r4.models import Subscription
+from api_fhir_r4.utils import TimeUtils
 
 
 class SubscriptionConverter(BaseFHIRConverter):
@@ -15,7 +16,7 @@ class SubscriptionConverter(BaseFHIRConverter):
     _error_forbidden_attr = f'`%(attr)s` attribute forbidden'
 
     @classmethod
-    def to_fhir_obj(cls, imis_subscription, reference_type):
+    def to_fhir_obj(cls, imis_subscription, reference_type=ReferenceConverterMixin.UUID_REFERENCE_TYPE):
         fhir_subscription = {}
         cls._build_fhir_id(fhir_subscription, imis_subscription)
         cls._build_fhir_status(fhir_subscription, imis_subscription)
@@ -58,7 +59,7 @@ class SubscriptionConverter(BaseFHIRConverter):
 
     @classmethod
     def _build_fhir_end(cls, fhir_subscription, imis_subscription):
-        fhir_subscription['end'] = imis_subscription.expiring
+        fhir_subscription['end'] = imis_subscription.expiring.astimezone()
 
     @classmethod
     def _build_fhir_reason(cls, fhir_subscription, imis_subscription):
@@ -116,7 +117,7 @@ class SubscriptionConverter(BaseFHIRConverter):
     @classmethod
     def _build_imis_end(cls, imis_subscription, fhir_subscription):
         if fhir_subscription.end:
-            imis_subscription['expiring'] = fhir_subscription.end
+            imis_subscription['expiring'] = TimeUtils.str_iso_to_date(fhir_subscription.end)
         else:
             raise FHIRException(cls._error_invalid_attr % {'attr': 'end'})
 

--- a/api_fhir_r4/serializers/subscriptionSerializer.py
+++ b/api_fhir_r4/serializers/subscriptionSerializer.py
@@ -19,10 +19,6 @@ class SubscriptionSerializer(BaseFHIRSerializer):
         'invoice': FHIRApiInvoicePermissions.permissions_get
     }
 
-    def to_internal_value(self, data):
-        data['end'] = TimeUtils.str_iso_to_date(data['end'])
-        return super().to_internal_value(data)
-
     def create(self, validated_data):
         user = self.context['request'].user
         self.check_resource_rights(user, validated_data)

--- a/api_fhir_r4/tests/mixin/SubscriptionTestMixin.py
+++ b/api_fhir_r4/tests/mixin/SubscriptionTestMixin.py
@@ -1,0 +1,62 @@
+from api_fhir_r4.models import Subscription
+from api_fhir_r4.tests import GenericTestMixin
+from api_fhir_r4.utils import TimeUtils
+
+from fhir.resources.subscription import Subscription as FHIRSubscription
+
+
+class SubscriptionTestMixin(GenericTestMixin):
+    _TEST_SUB_ENDPOINT = 'https://test.com/test'
+    _TEST_SUB_HEADERS = 'TestKey1=TestValue1&TestKey2=TestValue2'
+    _TEST_SUB_IMIS_EXPIRING = '2020-01-01T00:00:00+00:00'
+
+    _TEST_SUB_IMIS_CRITERIA = {
+        'resource_type': 'Patient',
+        'chfid__startswith': '0'
+    }
+    _TEST_SUB_IMIS_STATUS = 1
+    _TEST_SUB_IMIS_CHANNEL = 0
+
+    _TEST_SUB_FHIR_STATUS = 'active'
+    _TEST_SUB_FHIR_REASON = 'Patient'
+    _TEST_SUB_FHIR_CRITERIA = 'Patient?chfid__startswith=0'
+    _TEST_SUB_FHIR_CHANNEL_TYPE = 'rest-hook'
+
+    def create_test_imis_instance(self):
+        return Subscription(**{
+            'status': self._TEST_SUB_IMIS_STATUS,
+            'channel': self._TEST_SUB_IMIS_CHANNEL,
+            'endpoint': self._TEST_SUB_ENDPOINT,
+            'headers': self._TEST_SUB_HEADERS,
+            'criteria': self._TEST_SUB_IMIS_CRITERIA,
+            'expiring': TimeUtils.str_iso_to_date(self._TEST_SUB_IMIS_EXPIRING)
+        })
+
+    def verify_imis_instance(self, imis_obj):
+        self.assertEquals(imis_obj.status, self._TEST_SUB_IMIS_STATUS)
+        self.assertEquals(imis_obj.channel, self._TEST_SUB_IMIS_CHANNEL)
+        self.assertEquals(imis_obj.endpoint, self._TEST_SUB_ENDPOINT)
+        self.assertEquals(imis_obj.headers, self._TEST_SUB_HEADERS)
+        self.assertEquals(imis_obj.criteria, self._TEST_SUB_IMIS_CRITERIA)
+        self.assertEquals(imis_obj.expiring, TimeUtils.str_iso_to_date(self._TEST_SUB_IMIS_EXPIRING))
+
+    def create_test_fhir_instance(self):
+        return FHIRSubscription.parse_obj({
+            'status': self._TEST_SUB_FHIR_STATUS,
+            'criteria': self._TEST_SUB_FHIR_CRITERIA,
+            'end': self._TEST_SUB_IMIS_EXPIRING,
+            'reason': self._TEST_SUB_FHIR_REASON,
+            'channel': {
+                'type': self._TEST_SUB_FHIR_CHANNEL_TYPE,
+                'endpoint': self._TEST_SUB_ENDPOINT,
+                'header': [self._TEST_SUB_HEADERS]
+            }
+        })
+
+    def verify_fhir_instance(self, fhir_obj):
+        self.assertEquals(fhir_obj.status, self._TEST_SUB_FHIR_STATUS)
+        self.assertEquals(fhir_obj.criteria, self._TEST_SUB_FHIR_CRITERIA)
+        self.assertEquals(fhir_obj.end, TimeUtils.str_iso_to_date(self._TEST_SUB_IMIS_EXPIRING))
+        self.assertEquals(fhir_obj.channel.type, self._TEST_SUB_FHIR_CHANNEL_TYPE)
+        self.assertEquals(fhir_obj.channel.endpoint, self._TEST_SUB_ENDPOINT)
+        self.assertEquals(fhir_obj.channel.header, [self._TEST_SUB_HEADERS])

--- a/api_fhir_r4/tests/mixin/__init__.py
+++ b/api_fhir_r4/tests/mixin/__init__.py
@@ -1,3 +1,6 @@
+import json
+from pathlib import Path
+
 from django.test import TestCase
 
 
@@ -10,3 +13,59 @@ class FhirConverterTestMixin(TestCase):
 
     def verify_fhir_coding_exists(self, fhir_coding, expected_code):
         self.assertIsNotNone(next(iter([coding for coding in fhir_coding if coding.code == expected_code]), None))
+
+
+class ConvertToImisTestMixin:
+    @property
+    def converter(self):
+        raise NotImplementedError()
+
+    def create_test_fhir_instance(self):
+        raise NotImplementedError()
+
+    def verify_imis_instance(self, imis_instance):
+        raise NotImplementedError()
+
+    def test_to_imis_obj(self):
+        fhir_instance = self.create_test_fhir_instance()
+        imis_instance = self.converter.to_imis_obj(fhir_instance.dict(), None)
+        self.verify_imis_instance(imis_instance)
+
+
+class ConvertToFhirTestMixin:
+    @property
+    def converter(self):
+        raise NotImplementedError()
+
+    def create_test_imis_instance(self):
+        raise NotImplementedError()
+
+    def verify_fhir_instance(self, fhir_instance):
+        raise NotImplementedError()
+
+    def test_to_fhir_obj(self):
+        imis_instance = self.create_test_imis_instance()
+        fhir_instance = self.converter.to_fhir_obj(imis_instance)
+        self.verify_fhir_instance(fhir_instance)
+
+
+class ConvertJsonToFhirTestMixin:
+    @property
+    def fhir_resource(self):
+        raise NotImplementedError()
+
+    @property
+    def json_repr(self):
+        raise NotImplementedError()
+
+    def verify_fhir_instance(self, fhir_instance):
+        raise NotImplementedError()
+
+    def test_fhir_object_from_json(self):
+        fhir_instance = self.fhir_resource.parse_obj(self._load_json_repr())
+        self.verify_fhir_instance(fhir_instance)
+
+    def _load_json_repr(self):
+        test_root = Path(__file__).parent.parent
+        json_representation = open(test_root.joinpath(self.json_repr)).read()
+        return json.loads(json_representation)

--- a/api_fhir_r4/tests/mixin/fhirApiDeleteTestMixin.py
+++ b/api_fhir_r4/tests/mixin/fhirApiDeleteTestMixin.py
@@ -1,7 +1,7 @@
+from fhir.resources.operationoutcome import OperationOutcome
 from rest_framework import status
 
 from api_fhir_r4.configurations import R4IssueTypeConfig
-from api_fhir_r4.models import OperationOutcomeV2 as OperationOutcome
 
 
 class FhirApiDeleteTestMixin(object):

--- a/api_fhir_r4/tests/mixin/genericFhirAPITestMixin.py
+++ b/api_fhir_r4/tests/mixin/genericFhirAPITestMixin.py
@@ -7,7 +7,6 @@ from rest_framework import status
 
 from api_fhir_r4.configurations import R4IdentifierConfig
 from api_fhir_r4.converters import BaseFHIRConverter
-from fhir.resources.fhirabstractmodel import FHIRAbstractModel
 from fhir.resources.bundle import Bundle
 from api_fhir_r4.utils import DbManagerUtils
 

--- a/api_fhir_r4/tests/mixin/invoiceTestMixin.py
+++ b/api_fhir_r4/tests/mixin/invoiceTestMixin.py
@@ -14,14 +14,14 @@ class InvoiceTestMixin(GenericTestMixin, FhirConverterTestMixin):
     _TEST_INVOICE_CODE = 'TEST-CODE'
     _TEST_INVOICE_SUBJECT_TYPE_CODING = 'contribution'
     _TEST_INVOICE_THIRD_PARTY = Family()
-    _TEST_INVOICE_THIRD_PARTY_UUID = '98765432-1234-1234-1234-123456789012'
+    _TEST_INVOICE_THIRD_PARTY_UUID = '43C47D1E-5110-4880-8C53-6871E71BDDE8'
     _TEST_INVOICE_DATE = TimeUtils.str_iso_to_date('2021-01-01')
     _TEST_INVOICE_TOTAL_NET = 10000.0
     _TEST_INVOICE_TOTAL_GROSS = 10000.0
     _TEST_INVOICE_CURRENCY = 'USD'
     _TEST_LINE_ITEM_CHARGE_ITEM_CODING = 'policy'
-    _TEST_LiNE_ITEM_QUANTITY = 2
-    _TEST_LINE_ITEM_UNIT_PRICE = 5000.0
+    _TEST_LiNE_ITEM_QUANTITY = 1
+    _TEST_LINE_ITEM_UNIT_PRICE = 10000.0
     _TEST_LINE_ITEM_BASE_PRICE_COMPONENT_TYPE = 'base'
     _TEST_LINE_ITEM_DISCOUNT_COMPONENT_TYPE = 'discount'
     _TEST_LINE_ITEM_DISCOUNT = 0.1
@@ -62,8 +62,7 @@ class InvoiceTestMixin(GenericTestMixin, FhirConverterTestMixin):
 
     def verify_fhir_instance(self, fhir_obj):
         if not (hasattr(self, '_TEST_INVOICE_SUBJECT_TYPE') and hasattr(self, '_TEST_LINE_ITEM_CHARGE_ITEM')):
-            raise RuntimeError(
-                'To verify imis fhir instance first create imis instance with create_test_imis_instance()')
+            self.create_test_imis_instance()
 
         self.assertIs(type(fhir_obj), FHIRInvoice)
         self.assertEqual(fhir_obj.status, self._TEST_INVOICE_STATUS)

--- a/api_fhir_r4/tests/test/test_invoice.json
+++ b/api_fhir_r4/tests/test/test_invoice.json
@@ -1,106 +1,103 @@
 {
-  "fullUrl": "http://0.0.0.0:8000/api/api_fhir_r4/Invoice/233a684a-00b0-4493-b733-1c5d400740c9",
-  "resource": {
-    "resourceType": "Invoice",
-    "id": "233a684a-00b0-4493-b733-1c5d400740c9",
-    "identifier": [
-      {
-        "type": {
-          "coding": [
-            {
-              "system": "https://openimis.github.io/openimis_fhir_r4_ig/CodeSystem/openimis-identifiers",
-              "code": "UUID"
-            }
-          ]
-        },
-        "value": "233a684a-00b0-4493-b733-1c5d400740c9"
-      },
-      {
-        "type": {
-          "coding": [
-            {
-              "system": "https://openimis.github.io/openimis_fhir_r4_ig/CodeSystem/openimis-identifiers",
-              "code": "Code"
-            }
-          ]
-        },
-        "value": "IV-BCUL0001-111111119-2021-08"
-      }
-    ],
-    "status": "active",
-    "type": {
-      "coding": [
-        {
-          "system": "https://openimis.github.io/openimis_fhir_r4_ig/CodeSystem/invoice-type",
-          "code": "contribution",
-          "display": "Contribution"
-        }
-      ]
-    },
-    "recipient": {
-      "reference": "Patient/43C47D1E-5110-4880-8C53-6871E71BDDE8",
-      "type": "Patient",
-      "identifier": {
-        "type": {
-          "coding": [
-            {
-              "system": "https://openimis.github.io/openimis_fhir_r4_ig/CodeSystem/openimis-identifiers",
-              "code": "UUID"
-            }
-          ]
-        },
-        "value": "43C47D1E-5110-4880-8C53-6871E71BDDE8"
-      }
-    },
-    "date": "2021-08-20",
-    "lineItem": [
-      {
-        "chargeItemCodeableConcept": {
-          "coding": [
-            {
-              "system": "https://openimis.github.io/openimis_fhir_r4_ig/CodeSystem/invoice-charge-item",
-              "code": "policy",
-              "display": "Policy"
-            }
-          ]
-        },
-        "priceComponent": [
+  "resourceType": "Invoice",
+  "id": "233a684a-00b0-4493-b733-1c5d400740c9",
+  "identifier": [
+    {
+      "type": {
+        "coding": [
           {
-            "extension": [
-              {
-                "url": "https://openimis.github.io/openimis_fhir_r4_ig//StructureDefinition/unit-price",
-                "valueMoney": {
-                  "value": 10000.0,
-                  "currency": "USD"
-                }
-              }
-            ],
-            "type": "base",
-            "code": {
-              "coding": [
-                {
-                  "system": "Code",
-                  "code": "Code",
-                  "display": "BCUL0001"
-                }
-              ]
-            },
-            "factor": 1.0,
-            "amount": {
-              "value": 10000.0,
-              "currency": "USD"
-            }
+            "system": "https://openimis.github.io/openimis_fhir_r4_ig/CodeSystem/openimis-identifiers",
+            "code": "UUID"
           }
         ]
-      }
-    ],
-    "totalNet": {
-      "value": 10000.0,
-      "currency": "USD"
+      },
+      "value": "233a684a-00b0-4493-b733-1c5d400740c9"
     },
-    "totalGross": {
-      "value": 10000.0,
-      "currency": "USD"
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "https://openimis.github.io/openimis_fhir_r4_ig/CodeSystem/openimis-identifiers",
+            "code": "Code"
+          }
+        ]
+      },
+      "value": "TEST-CODE"
     }
+  ],
+  "status": "active",
+  "type": {
+    "coding": [
+      {
+        "system": "https://openimis.github.io/openimis_fhir_r4_ig/CodeSystem/invoice-type",
+        "code": "contribution",
+        "display": "Contribution"
+      }
+    ]
+  },
+  "recipient": {
+    "reference": "Group/43C47D1E-5110-4880-8C53-6871E71BDDE8",
+    "type": "Group",
+    "identifier": {
+      "type": {
+        "coding": [
+          {
+            "system": "https://openimis.github.io/openimis_fhir_r4_ig/CodeSystem/openimis-identifiers",
+            "code": "UUID"
+          }
+        ]
+      },
+      "value": "43C47D1E-5110-4880-8C53-6871E71BDDE8"
+    }
+  },
+  "date": "2021-01-01",
+  "lineItem": [
+    {
+      "chargeItemCodeableConcept": {
+        "coding": [
+          {
+            "system": "https://openimis.github.io/openimis_fhir_r4_ig/CodeSystem/invoice-charge-item",
+            "code": "policy",
+            "display": "Policy"
+          }
+        ]
+      },
+      "priceComponent": [
+        {
+          "extension": [
+            {
+              "url": "https://openimis.github.io/openimis_fhir_r4_ig//StructureDefinition/unit-price",
+              "valueMoney": {
+                "value": 10000.0,
+                "currency": "USD"
+              }
+            }
+          ],
+          "type": "base",
+          "code": {
+            "coding": [
+              {
+                "system": "Code",
+                "code": "Code",
+                "display": "BCUL0001"
+              }
+            ]
+          },
+          "factor": 1.0,
+          "amount": {
+            "value": 10000.0,
+            "currency": "USD"
+          }
+        }
+      ]
+    }
+  ],
+  "totalNet": {
+    "value": 10000.0,
+    "currency": "USD"
+  },
+  "totalGross": {
+    "value": 10000.0,
+    "currency": "USD"
   }
 }

--- a/api_fhir_r4/tests/test/test_subscription.json
+++ b/api_fhir_r4/tests/test/test_subscription.json
@@ -1,0 +1,13 @@
+{
+  "status": "active",
+  "end": "2020-01-01T00:00:00+00:00",
+  "reason": "Patient",
+  "criteria": "Patient?chfid__startswith=0",
+  "channel": {
+    "type": "rest-hook",
+    "endpoint": "https://test.com/test",
+    "header": [
+      "TestKey1=TestValue1&TestKey2=TestValue2"
+    ]
+  }
+}

--- a/api_fhir_r4/tests/test_api_invoice.py
+++ b/api_fhir_r4/tests/test_api_invoice.py
@@ -18,8 +18,3 @@ class InvoiceAPITests(GenericFhirAPITestMixin, FhirApiReadTestMixin, APITestCase
         self.imis_invoice.thirdparty = Insuree.objects.first()
         self.imis_invoice.save(username=user.username)
         self.imis_invoice_line_item.save(username=user.username)
-
-    def tearDown(self):
-        user = self.get_or_create_user_api()
-        self.imis_invoice_line_item.delete(username=user.username)
-        self.imis_invoice.delete(username=user.username)

--- a/api_fhir_r4/tests/test_api_subscription.py
+++ b/api_fhir_r4/tests/test_api_subscription.py
@@ -1,0 +1,30 @@
+from rest_framework.test import APITestCase
+from api_fhir_r4.configurations import GeneralConfiguration
+from api_fhir_r4.tests import GenericFhirAPITestMixin, FhirApiCreateTestMixin, FhirApiReadTestMixin, \
+    FhirApiDeleteTestMixin, FhirApiUpdateTestMixin
+from api_fhir_r4.tests.mixin.SubscriptionTestMixin import SubscriptionTestMixin
+from api_fhir_r4.tests.mixin.logInMixin import LogInMixin
+
+
+class SubscriptionAPITests(GenericFhirAPITestMixin, APITestCase, LogInMixin, FhirApiCreateTestMixin,
+                           FhirApiReadTestMixin, FhirApiDeleteTestMixin, FhirApiUpdateTestMixin,
+                           SubscriptionTestMixin):
+    base_url = GeneralConfiguration.get_base_url() + 'Subscription/'
+    _test_json_path = "/test/test_subscription.json"
+    _updated_endpoint = 'https://modifiedendpoint.com'
+
+    def update_resource(self, data):
+        data['channel']['endpoint'] = self._updated_endpoint
+
+    def verify_updated_obj(self, obj):
+        self.assertEqual(obj.channel.endpoint, self._updated_endpoint)
+
+    def setUp(self):
+        super(SubscriptionAPITests, self).setUp()
+        user = self.get_or_create_user_api()
+        subscription = self.create_test_imis_instance()
+        subscription.id = None
+        subscription.save(username=user.username)
+
+    def get_id_for_created_resource(self, response):
+        return response.data['id']

--- a/api_fhir_r4/tests/test_bill.py
+++ b/api_fhir_r4/tests/test_bill.py
@@ -1,27 +1,19 @@
-import json
 import os
 
-from api_fhir_r4.converters import InvoiceConverter, BillInvoiceConverter
+from fhir.resources.invoice import Invoice
+
+from api_fhir_r4.converters import BillInvoiceConverter
+from api_fhir_r4.tests.mixin import ConvertToFhirTestMixin
 from api_fhir_r4.tests.mixin.billInvoiceTestMixin import BillInvoiceTestMixin
-from api_fhir_r4.tests.mixin.invoiceTestMixin import InvoiceTestMixin
 
 
-class InvoiceConverterInvoiceTestCase(BillInvoiceTestMixin):
-    __TEST_INVOICE_JSON_PATH = "/test/test_invoice.json"
-
-    @classmethod
-    def setUpClass(cls):
-        super(InvoiceConverterInvoiceTestCase, cls).setUpClass()
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        cls.__TEST_INVOICE_JSON_TEXT__ = open(dir_path + cls.__TEST_INVOICE_JSON_PATH).read()
+class InvoiceConverterInvoiceTestCase(BillInvoiceTestMixin, ConvertToFhirTestMixin):
+    converter = BillInvoiceConverter
+    fhir_resource = Invoice
+    json_repr = 'test/test_invoice.json'
 
     def setUp(self):
         super(InvoiceConverterInvoiceTestCase, self).setUp()
 
-    def test_to_fhir_obj(self):
-        imis_invoice = self.create_test_imis_instance()
-        fhir_invoice = BillInvoiceConverter.to_fhir_obj(imis_invoice)
-        self.verify_fhir_instance(fhir_invoice)
-
     def test_to_imis_obj(self):
-        self.assertRaises(NotImplementedError, InvoiceConverter.to_imis_obj, object(), 1)
+        self.assertRaises(NotImplementedError, self.converter.to_imis_obj, object(), 1)

--- a/api_fhir_r4/tests/test_claimAdminPractitionerConverter.py
+++ b/api_fhir_r4/tests/test_claimAdminPractitionerConverter.py
@@ -1,32 +1,14 @@
-import json
-import os
-
 from api_fhir_r4.converters import ClaimAdminPractitionerConverter
 
 from fhir.resources.practitioner import Practitioner
 from api_fhir_r4.tests import ClaimAdminPractitionerTestMixin
+from api_fhir_r4.tests.mixin import ConvertToImisTestMixin, ConvertToFhirTestMixin, ConvertJsonToFhirTestMixin
 
 
-class ClaimAdminPractitionerConverterTestCase(ClaimAdminPractitionerTestMixin):
-
-    __TEST_PRACTITIONER_JSON_PATH = "/test/test_claimAdminPractitioner.json"
-
-    def setUp(self):
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        self._test_practitioner_json_representation = open(dir_path + self.__TEST_PRACTITIONER_JSON_PATH).read()
-
-    def test_to_fhir_obj(self):
-        imis_claim_admin = self.create_test_imis_instance()
-        fhir_practitioner = ClaimAdminPractitionerConverter.to_fhir_obj(imis_claim_admin)
-        self.verify_fhir_instance(fhir_practitioner)
-
-    def test_to_imis_obj(self):
-        fhir_practitioner = self.create_test_fhir_instance()
-        imis_claim_admin = ClaimAdminPractitionerConverter.to_imis_obj(fhir_practitioner.dict(), None)
-        self.verify_imis_instance(imis_claim_admin)
-
-    def test_create_object_from_json(self):
-        self.setUp()
-        dict_practitioner = json.loads(self._test_practitioner_json_representation)
-        fhir_practitioner = Practitioner(**dict_practitioner)
-        self.verify_fhir_instance(fhir_practitioner)
+class ClaimAdminPractitionerConverterTestCase(ClaimAdminPractitionerTestMixin,
+                                              ConvertToImisTestMixin,
+                                              ConvertToFhirTestMixin,
+                                              ConvertJsonToFhirTestMixin):
+    converter = ClaimAdminPractitionerConverter
+    fhir_resource = Practitioner
+    json_repr = 'test/test_claimAdminPractitioner.json'

--- a/api_fhir_r4/tests/test_claimAdminPractitionerRoleConverter.py
+++ b/api_fhir_r4/tests/test_claimAdminPractitionerRoleConverter.py
@@ -1,34 +1,13 @@
-import json
-import os
-
 from api_fhir_r4.converters import ClaimAdminPractitionerRoleConverter
 from fhir.resources.practitionerrole import PractitionerRole
 from api_fhir_r4.tests import ClaimAdminPractitionerRoleTestMixin
+from api_fhir_r4.tests.mixin import ConvertJsonToFhirTestMixin, ConvertToFhirTestMixin, ConvertToImisTestMixin
 
 
-class ClaimAdminPractitionerRoleConverterTestCase(ClaimAdminPractitionerRoleTestMixin):
-
-    __TEST_PRACTITIONER_ROLE_JSON_PATH = "/test/test_claimAdminPractitionerRole.json"
-
-    def setUp(self):
-        super(ClaimAdminPractitionerRoleConverterTestCase, self).setUp()
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        self._test_practitioner_role_json_representation = open(
-            dir_path + self.__TEST_PRACTITIONER_ROLE_JSON_PATH).read()
-        if self._test_practitioner_role_json_representation[-1:] == "\n":
-            self._test_practitioner_role_json_representation = self._test_practitioner_role_json_representation[:-1]
-
-    def test_to_fhir_obj(self):
-        imis_claim_admin = self.create_test_imis_instance()
-        fhir_practitioner_role = ClaimAdminPractitionerRoleConverter.to_fhir_obj(imis_claim_admin)
-        self.verify_fhir_instance(fhir_practitioner_role)
-
-    def test_to_imis_obj(self):
-        fhir_practitioner_role = self.create_test_fhir_instance()
-        imis_claim_admin = ClaimAdminPractitionerRoleConverter.to_imis_obj(fhir_practitioner_role.dict(), None)
-        self.verify_imis_instance(imis_claim_admin)
-
-    def test_create_object_from_json(self):
-        dict_practitioner_role = json.loads(self._test_practitioner_role_json_representation)
-        fhir_practitioner_role = PractitionerRole(**dict_practitioner_role)
-        self.verify_fhir_instance(fhir_practitioner_role)
+class ClaimAdminPractitionerRoleConverterTestCase(ClaimAdminPractitionerRoleTestMixin,
+                                                  ConvertToImisTestMixin,
+                                                  ConvertToFhirTestMixin,
+                                                  ConvertJsonToFhirTestMixin):
+    converter = ClaimAdminPractitionerRoleConverter
+    fhir_resource = PractitionerRole
+    json_repr = 'test/test_claimAdminPractitionerRole.json'

--- a/api_fhir_r4/tests/test_claimConverter.py
+++ b/api_fhir_r4/tests/test_claimConverter.py
@@ -1,34 +1,13 @@
-import json
-import os
-
-
 from api_fhir_r4.converters.claimConverter import ClaimConverter
 from api_fhir_r4.models import ClaimV2 as Claim
 from api_fhir_r4.tests import ClaimTestMixin
+from api_fhir_r4.tests.mixin import ConvertToImisTestMixin, ConvertToFhirTestMixin, ConvertJsonToFhirTestMixin
 
 
-class ClaimConverterTestCase(ClaimTestMixin):
-
-    __TEST_CLAIM_JSON_PATH = "/test/test_claim.json"
-
-    def setUp(self):
-        super(ClaimConverterTestCase, self).setUp()
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        self._test_claim_json_representation = open(dir_path + self.__TEST_CLAIM_JSON_PATH).read()
-        if self._test_claim_json_representation[-1:] == "\n":
-            self._test_claim_json_representation = self._test_claim_json_representation[:-1]
-
-    def test_to_fhir_obj(self):
-        imis_claim = self.create_test_imis_instance()
-        fhir_claim = ClaimConverter.to_fhir_obj(imis_claim)
-        self.verify_fhir_instance(fhir_claim)
-
-    def test_to_imis_obj(self):
-        fhir_claim = self.create_test_fhir_instance()
-        imis_claim = ClaimConverter.to_imis_obj(fhir_claim.dict(), None)
-        self.verify_imis_instance(imis_claim)
-
-    def test_create_object_from_json(self):
-        dict_claim = json.loads(self._test_claim_json_representation)
-        fhir_claim = Claim(**dict_claim)
-        self.verify_fhir_instance(fhir_claim)
+class ClaimConverterTestCase(ClaimTestMixin,
+                             ConvertToImisTestMixin,
+                             ConvertToFhirTestMixin,
+                             ConvertJsonToFhirTestMixin):
+    converter = ClaimConverter
+    fhir_resource = Claim
+    json_repr = 'test/test_claim.json'

--- a/api_fhir_r4/tests/test_claimResponseConverter.py
+++ b/api_fhir_r4/tests/test_claimResponseConverter.py
@@ -1,25 +1,12 @@
-import os
-import json
 from api_fhir_r4.converters import ClaimResponseConverter
 from api_fhir_r4.models import ClaimResponseV2 as ClaimResponse
 from api_fhir_r4.tests import ClaimResponseTestMixin
+from api_fhir_r4.tests.mixin import ConvertToFhirTestMixin, ConvertJsonToFhirTestMixin
 
 
-class ClaimResponseConverterTestCase(ClaimResponseTestMixin):
-
-    __TEST_CLAIM_RESPONSE_JSON_PATH = "/test/test_claimResponse.json"
-
-    def setUp(self):
-        super(ClaimResponseConverterTestCase, self).setUp()
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        self._test_claim_response_json_representation = open(dir_path + self.__TEST_CLAIM_RESPONSE_JSON_PATH).read()
-
-    def test_to_fhir_obj(self):
-        imis_claim = self.create_test_imis_instance()
-        fhir_claim_response = ClaimResponseConverter.to_fhir_obj(imis_claim)
-        self.verify_fhir_instance(fhir_claim_response)
-
-    def test_create_object_from_json(self):
-        dict_claim_response = json.loads(self._test_claim_response_json_representation)
-        fhir_claim_response = ClaimResponse(**dict_claim_response)
-        self.verify_fhir_instance(fhir_claim_response)
+class ClaimResponseConverterTestCase(ClaimResponseTestMixin,
+                                     ConvertToFhirTestMixin,
+                                     ConvertJsonToFhirTestMixin):
+    converter = ClaimResponseConverter
+    fhir_resource = ClaimResponse
+    json_repr = 'test/test_claimResponse.json'

--- a/api_fhir_r4/tests/test_communicationConverter.py
+++ b/api_fhir_r4/tests/test_communicationConverter.py
@@ -1,31 +1,14 @@
-import json
-import os
-
 from api_fhir_r4.converters import CommunicationConverter
 from api_fhir_r4.tests import CommunicationTestMixin
 from fhir.resources.communication import Communication
 
+from api_fhir_r4.tests.mixin import ConvertToImisTestMixin, ConvertToFhirTestMixin, ConvertJsonToFhirTestMixin
 
-class CommunicationConverterTestCase(CommunicationTestMixin):
 
-    __TEST_COMMUNICATION_JSON_PATH = "/test/test_communication.json"
-
-    def setUp(self):
-        super(CommunicationConverterTestCase, self).setUp()
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        self._test_communication_json_representation = open(dir_path + self.__TEST_COMMUNICATION_JSON_PATH).read()
-
-    def test_to_fhir_obj(self):
-        imis_feedback = self.create_test_imis_instance()
-        fhir_communication = CommunicationConverter.to_fhir_obj(imis_feedback)
-        self.verify_fhir_instance(fhir_communication)
-
-    def test_to_imis_obj(self):
-        fhir_communication = self.create_test_fhir_instance()
-        imis_feedback = CommunicationConverter.to_imis_obj(fhir_communication.dict(), None)
-        self.verify_imis_instance(imis_feedback)
-
-    def test_create_object_from_json(self):
-        dict_communication = json.loads(self._test_communication_json_representation)
-        fhir_communication = Communication(**dict_communication)
-        self.verify_fhir_instance(fhir_communication)
+class CommunicationConverterTestCase(CommunicationTestMixin,
+                                     ConvertToImisTestMixin,
+                                     ConvertToFhirTestMixin,
+                                     ConvertJsonToFhirTestMixin):
+    converter = CommunicationConverter
+    fhir_resource = Communication
+    json_repr = 'test/test_communication.json'

--- a/api_fhir_r4/tests/test_communicationRequestConverter.py
+++ b/api_fhir_r4/tests/test_communicationRequestConverter.py
@@ -1,29 +1,12 @@
-import json
-import os
-
 from api_fhir_r4.converters import CommunicationRequestConverter
 from fhir.resources.communicationrequest import CommunicationRequest
 from api_fhir_r4.tests import CommunicationRequestTestMixin
+from api_fhir_r4.tests.mixin import ConvertToFhirTestMixin, ConvertJsonToFhirTestMixin
 
 
-class CommunicationRequestConverterTestCase(CommunicationRequestTestMixin):
-
-    __TEST_COMMUNICATION_REQUEST_JSON_PATH = "/test/test_communicationRequest.json"
-
-    def setUp(self):
-        super(CommunicationRequestConverterTestCase, self).setUp()
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        self._test_communication_request_json_representation = open(dir_path + self.__TEST_COMMUNICATION_REQUEST_JSON_PATH).read()
-        # .dumps() will not put a newline at the end of the "file" but editors will
-        if self._test_communication_request_json_representation[-1:] == "\n":
-            self._test_communication_request_json_representation = self._test_communication_request_json_representation[:-1]
-
-    def test_to_fhir_obj(self):
-        imis_claim = self.create_test_imis_instance()
-        fhir_communication_request = CommunicationRequestConverter.to_fhir_obj(imis_claim)
-        self.verify_fhir_instance(fhir_communication_request)
-
-    def test_fhir_object_to_json_request(self):
-        dict_communication_request = json.loads(self._test_communication_request_json_representation)
-        fhir_communication_request = CommunicationRequest(**dict_communication_request)
-        self.verify_fhir_instance(fhir_communication_request)
+class CommunicationRequestConverterTestCase(CommunicationRequestTestMixin,
+                                            ConvertToFhirTestMixin,
+                                            ConvertJsonToFhirTestMixin):
+    converter = CommunicationRequestConverter
+    fhir_resource = CommunicationRequest
+    json_repr = 'test/test_communicationRequest.json'

--- a/api_fhir_r4/tests/test_contractConverter.py
+++ b/api_fhir_r4/tests/test_contractConverter.py
@@ -1,34 +1,14 @@
-import json
-import os
-
 from api_fhir_r4.converters import ContractConverter
 from api_fhir_r4.tests import ContractTestMixin
 from fhir.resources.contract import Contract
 
+from api_fhir_r4.tests.mixin import ConvertToImisTestMixin, ConvertToFhirTestMixin, ConvertJsonToFhirTestMixin
 
-class ContractConverterTestCase(ContractTestMixin):
 
-    __TEST_CONTRACT_JSON_PATH = "/test/test_contract.json"
-
-    def setUp(self):
-        super(ContractConverterTestCase, self).setUp()
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        self._test_contract_json_representation = open(dir_path + self.__TEST_CONTRACT_JSON_PATH).read()
-
-    def test_to_fhir_obj(self):
-        self.setUp()
-        imis_policy = self.create_test_imis_instance()
-        fhir_contract = ContractConverter.to_fhir_obj(imis_policy)
-        self.verify_fhir_instance(fhir_contract)
-
-    def test_to_imis_obj(self):
-        self.setUp()
-        fhir_contract = self.create_test_fhir_instance()
-        imis_policy = ContractConverter.to_imis_obj(fhir_contract.dict(), None)
-        self.verify_imis_instance(imis_policy)
-
-    def test_create_object_from_json(self):
-        self.setUp()
-        dict_contract = json.loads(self._test_contract_json_representation)
-        fhir_contract = Contract(**dict_contract)
-        self.verify_fhir_instance(fhir_contract)
+class ContractConverterTestCase(ContractTestMixin,
+                                ConvertToImisTestMixin,
+                                ConvertToFhirTestMixin,
+                                ConvertJsonToFhirTestMixin):
+    converter = ContractConverter
+    fhir_resource = Contract
+    json_repr = 'test/test_contract.json'

--- a/api_fhir_r4/tests/test_coverageConverter.py
+++ b/api_fhir_r4/tests/test_coverageConverter.py
@@ -1,26 +1,12 @@
-import json
-import os
-
 from api_fhir_r4.converters.coverageConverter import CoverageConverter
 from api_fhir_r4.tests import CoverageTestMixin
 from api_fhir_r4.models import CoverageV2 as Coverage
+from api_fhir_r4.tests.mixin import ConvertToFhirTestMixin, ConvertJsonToFhirTestMixin
 
 
-class CoverageConverterTestCase(CoverageTestMixin):
-
-    __TEST_COVERAGE_JSON_PATH = "/test/test_coverage.json"
-
-    def setUp(self):
-        super(CoverageConverterTestCase, self).setUp()
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        self._test_coverage_json_representation = open(dir_path + self.__TEST_COVERAGE_JSON_PATH).read()
-
-    def test_to_fhir_obj(self):
-        imis_policy = self.create_test_imis_instance()
-        fhir_coverage = CoverageConverter.to_fhir_obj(imis_policy)
-        self.verify_fhir_instance(fhir_coverage)
-
-    def test_create_object_from_json(self):
-        dict_coverage = json.loads(self._test_coverage_json_representation)
-        fhir_coverage = Coverage(**dict_coverage)
-        self.verify_fhir_instance(fhir_coverage)
+class CoverageConverterTestCase(CoverageTestMixin,
+                                ConvertToFhirTestMixin,
+                                ConvertJsonToFhirTestMixin):
+    converter = CoverageConverter
+    fhir_resource = Coverage
+    json_repr = 'test/test_coverage.json'

--- a/api_fhir_r4/tests/test_enrolmentOfficerPractitionerConverter.py
+++ b/api_fhir_r4/tests/test_enrolmentOfficerPractitionerConverter.py
@@ -1,32 +1,14 @@
-import json
-import os
-
 from api_fhir_r4.converters import EnrolmentOfficerPractitionerConverter
 
 from fhir.resources.practitioner import Practitioner
 from api_fhir_r4.tests import EnrolmentOfficerPractitionerTestMixin
+from api_fhir_r4.tests.mixin import ConvertToImisTestMixin, ConvertToFhirTestMixin, ConvertJsonToFhirTestMixin
 
 
-class EnrolmentOfficerPractitionerConverterTestCase(EnrolmentOfficerPractitionerTestMixin):
-
-    __TEST_PRACTITIONER_JSON_PATH = "/test/test_enrolmentOfficerPractitioner.json"
-
-    def setUp(self):
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        self._test_practitioner_json_representation = open(dir_path + self.__TEST_PRACTITIONER_JSON_PATH).read()
-
-    def test_to_fhir_obj(self):
-        imis_officer = self.create_test_imis_instance()
-        fhir_practitioner = EnrolmentOfficerPractitionerConverter.to_fhir_obj(imis_officer)
-        self.verify_fhir_instance(fhir_practitioner)
-
-    def test_to_imis_obj(self):
-        fhir_practitioner = self.create_test_fhir_instance()
-        imis_officer = EnrolmentOfficerPractitionerConverter.to_imis_obj(fhir_practitioner.dict(), None)
-        self.verify_imis_instance(imis_officer)
-
-    def test_create_object_from_json(self):
-        self.setUp()
-        dict_practitioner = json.loads(self._test_practitioner_json_representation)
-        fhir_practitioner = Practitioner(**dict_practitioner)
-        self.verify_fhir_instance(fhir_practitioner)
+class EnrolmentOfficerPractitionerConverterTestCase(EnrolmentOfficerPractitionerTestMixin,
+                                                    ConvertToImisTestMixin,
+                                                    ConvertToFhirTestMixin,
+                                                    ConvertJsonToFhirTestMixin):
+    converter = EnrolmentOfficerPractitionerConverter
+    fhir_resource = Practitioner
+    json_repr = 'test/test_enrolmentOfficerPractitioner.json'

--- a/api_fhir_r4/tests/test_enrolmentOfficerPractitionerRoleConverter.py
+++ b/api_fhir_r4/tests/test_enrolmentOfficerPractitionerRoleConverter.py
@@ -1,34 +1,13 @@
-import json
-import os
-
 from api_fhir_r4.converters import EnrolmentOfficerPractitionerRoleConverter
 from fhir.resources.practitionerrole import PractitionerRole
 from api_fhir_r4.tests import EnrolmentOfficerPractitionerRoleTestMixin
+from api_fhir_r4.tests.mixin import ConvertToImisTestMixin, ConvertToFhirTestMixin, ConvertJsonToFhirTestMixin
 
 
-class EnrolmentOfficerPractitionerRoleConverterTestCase(EnrolmentOfficerPractitionerRoleTestMixin):
-
-    __TEST_PRACTITIONER_ROLE_JSON_PATH = "/test/test_enrolmentOfficerPractitionerRole.json"
-
-    def setUp(self):
-        super(EnrolmentOfficerPractitionerRoleConverterTestCase, self).setUp()
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        self._test_practitioner_role_json_representation = open(
-            dir_path + self.__TEST_PRACTITIONER_ROLE_JSON_PATH).read()
-        if self._test_practitioner_role_json_representation[-1:] == "\n":
-            self._test_practitioner_role_json_representation = self._test_practitioner_role_json_representation[:-1]
-
-    def test_to_fhir_obj(self):
-        imis_officer = self.create_test_imis_instance()
-        fhir_practitioner_role = EnrolmentOfficerPractitionerRoleConverter.to_fhir_obj(imis_officer)
-        self.verify_fhir_instance(fhir_practitioner_role)
-
-    def test_to_imis_obj(self):
-        fhir_practitioner_role = self.create_test_fhir_instance()
-        imis_officer = EnrolmentOfficerPractitionerRoleConverter.to_imis_obj(fhir_practitioner_role.dict(), None)
-        self.verify_imis_instance(imis_officer)
-
-    def test_create_object_from_json(self):
-        dict_practitioner_role = json.loads(self._test_practitioner_role_json_representation)
-        fhir_practitioner_role = PractitionerRole(**dict_practitioner_role)
-        self.verify_fhir_instance(fhir_practitioner_role)
+class EnrolmentOfficerPractitionerRoleConverterTestCase(EnrolmentOfficerPractitionerRoleTestMixin,
+                                                        ConvertToImisTestMixin,
+                                                        ConvertToFhirTestMixin,
+                                                        ConvertJsonToFhirTestMixin):
+    converter = EnrolmentOfficerPractitionerRoleConverter
+    fhir_resource = PractitionerRole
+    json_repr = 'test/test_enrolmentOfficerPractitionerRole.json'

--- a/api_fhir_r4/tests/test_groupConverter.py
+++ b/api_fhir_r4/tests/test_groupConverter.py
@@ -1,36 +1,14 @@
-import json
-import os
-
 from api_fhir_r4.converters import GroupConverter
 
 from fhir.resources.group import Group
 from api_fhir_r4.tests import GroupTestMixin
+from api_fhir_r4.tests.mixin import ConvertToImisTestMixin, ConvertToFhirTestMixin, ConvertJsonToFhirTestMixin
 
 
-class GroupConverterTestCase(GroupTestMixin):
-
-    __TEST_GROUP_JSON_PATH = "/test/test_group.json"
-
-    def setUp(self):
-        super(GroupConverterTestCase, self).setUp()
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        self._test_group_json_representation = open(dir_path + self.__TEST_GROUP_JSON_PATH).read()
-
-    def test_to_fhir_obj(self):
-        self.setUp()
-        imis_family = self.create_test_imis_instance()
-        fhir_group = GroupConverter.to_fhir_obj(imis_family)
-        self.verify_fhir_instance(fhir_group)
-
-    def test_to_imis_obj(self):
-        self.setUp()
-        fhir_group = self.create_test_fhir_instance()
-        imis_family = GroupConverter.to_imis_obj(fhir_group.dict(), None)
-        self.verify_imis_instance(imis_family)
-
-    def test_create_object_from_json(self):
-        self.setUp()
-        dict_group = json.loads(self._test_group_json_representation)
-        fhir_group = Group(**dict_group)
-        self.verify_fhir_instance(fhir_group)
-
+class GroupConverterTestCase(GroupTestMixin,
+                             ConvertToImisTestMixin,
+                             ConvertToFhirTestMixin,
+                             ConvertJsonToFhirTestMixin):
+    converter = GroupConverter
+    fhir_resource = Group
+    json_repr = 'test/test_group.json'

--- a/api_fhir_r4/tests/test_insurancePlanConverter.py
+++ b/api_fhir_r4/tests/test_insurancePlanConverter.py
@@ -2,36 +2,16 @@ import json
 import os
 
 from api_fhir_r4.converters import InsurancePlanConverter
-from collections import OrderedDict
-from django.core.serializers.json import DjangoJSONEncoder
 
 from fhir.resources.insuranceplan import InsurancePlan
 from api_fhir_r4.tests import InsurancePlanTestMixin
+from api_fhir_r4.tests.mixin import ConvertToImisTestMixin, ConvertToFhirTestMixin, ConvertJsonToFhirTestMixin
 
 
-class InsurancePlanConverterTestCase(InsurancePlanTestMixin):
-
-    __TEST_INSURANCE_PLAN_JSON_PATH = "/test/test_insurance_plan.json"
-
-    def setUp(self):
-        super(InsurancePlanConverterTestCase, self).setUp()
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        self._test_insurance_plan_json_representation = open(dir_path + self.__TEST_INSURANCE_PLAN_JSON_PATH).read()
-
-    def test_to_fhir_obj(self):
-        self.setUp()
-        imis_product = self.create_test_imis_instance()
-        fhir_insurance_plan = InsurancePlanConverter.to_fhir_obj(imis_product)
-        self.verify_fhir_instance(fhir_insurance_plan)
-
-    def test_to_imis_obj(self):
-        self.setUp()
-        fhir_insurance_plan = self.create_test_fhir_instance()
-        imis_product = InsurancePlanConverter.to_imis_obj(fhir_insurance_plan.dict(), None)
-        self.verify_imis_instance(imis_product)
-
-    def test_create_object_from_json(self):
-        self.setUp()
-        dict_insurance_plan = json.loads(self._test_insurance_plan_json_representation)
-        fhir_insurance_plan = InsurancePlan(**dict_insurance_plan)
-        self.verify_fhir_instance(fhir_insurance_plan)
+class InsurancePlanConverterTestCase(InsurancePlanTestMixin,
+                                     ConvertToImisTestMixin,
+                                     ConvertToFhirTestMixin,
+                                     ConvertJsonToFhirTestMixin):
+    converter = InsurancePlanConverter
+    fhir_resource = InsurancePlan
+    json_repr = 'test/test_insurance_plan.json'

--- a/api_fhir_r4/tests/test_invoiceConverter.py
+++ b/api_fhir_r4/tests/test_invoiceConverter.py
@@ -1,32 +1,25 @@
-import os
+from fhir.resources.invoice import Invoice
 
 from api_fhir_r4.converters import InvoiceConverter
+from api_fhir_r4.tests.mixin import ConvertJsonToFhirTestMixin
 from api_fhir_r4.tests.mixin.invoiceTestMixin import InvoiceTestMixin
 from api_fhir_r4.tests.mixin.logInMixin import LogInMixin
 
 
-class InvoiceConverterTestCase(InvoiceTestMixin, LogInMixin):
+class InvoiceConverterTestCase(InvoiceTestMixin, LogInMixin, ConvertJsonToFhirTestMixin):
     _TEST_USER_NAME = "TestUserTest2"
-    __TEST_INVOICE_JSON_PATH = "/test/test_invoice.json"
 
-    @classmethod
-    def setUpClass(cls):
-        super(InvoiceConverterTestCase, cls).setUpClass()
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        cls.__TEST_INVOICE_JSON_TEXT__ = open(dir_path + cls.__TEST_INVOICE_JSON_PATH).read()
-
-    def setUp(self):
-        super(InvoiceConverterTestCase, self).setUp()
+    converter = InvoiceConverter
+    fhir_resource = Invoice
+    json_repr = 'test/test_invoice.json'
 
     def test_to_fhir_obj(self):
         user = self.get_or_create_user_api()
         imis_invoice, imis_invoice_line_item = self.create_test_imis_instance()
         imis_invoice.save(username=user.username)
         imis_invoice_line_item.save(username=user.username)
-        fhir_invoice = InvoiceConverter.to_fhir_obj(imis_invoice)
+        fhir_invoice = self.converter.to_fhir_obj(imis_invoice)
         self.verify_fhir_instance(fhir_invoice)
-        imis_invoice_line_item.delete(username=user.username)
-        imis_invoice.delete(username=user.username)
 
     def test_to_imis_obj(self):
         self.assertRaises(NotImplementedError, InvoiceConverter.to_imis_obj, object(), 1)

--- a/api_fhir_r4/tests/test_locationConverter.py
+++ b/api_fhir_r4/tests/test_locationConverter.py
@@ -1,31 +1,13 @@
-import json
-import os
-
 from api_fhir_r4.converters.locationConverter import LocationConverter
 from fhir.resources.location import Location
 from api_fhir_r4.tests import LocationTestMixin
+from api_fhir_r4.tests.mixin import ConvertToImisTestMixin, ConvertToFhirTestMixin, ConvertJsonToFhirTestMixin
 
 
-class LocationConverterTestCase(LocationTestMixin):
-
-    __TEST_LOCATION_JSON_PATH = "/test/test_location.json"
-
-    def setUp(self):
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        self._test_location_json_representation = open(dir_path + self.__TEST_LOCATION_JSON_PATH).read()
-
-    def test_to_fhir_obj(self):
-        imis_hf = self.create_test_imis_instance()
-        fhir_location = LocationConverter.to_fhir_obj(imis_hf)
-        self.verify_fhir_instance(fhir_location)
-
-    def test_to_imis_obj(self):
-        fhir_loaction = self.create_test_fhir_instance()
-        imis_hf = LocationConverter.to_imis_obj(fhir_loaction.dict(), None)
-        self.verify_imis_instance(imis_hf)
-
-    def test_create_object_from_json(self):
-        self.setUp()
-        dict_location = json.loads(self._test_location_json_representation)
-        fhir_location = Location(**dict_location)
-        self.verify_fhir_instance(fhir_location)
+class LocationConverterTestCase(LocationTestMixin,
+                                ConvertToImisTestMixin,
+                                ConvertToFhirTestMixin,
+                                ConvertJsonToFhirTestMixin):
+    converter = LocationConverter
+    fhir_resource = Location
+    json_repr = 'test/test_location.json'

--- a/api_fhir_r4/tests/test_medicationConverter.py
+++ b/api_fhir_r4/tests/test_medicationConverter.py
@@ -1,35 +1,14 @@
-import json
-import os
-
 from api_fhir_r4.converters import MedicationConverter
 
 from fhir.resources.medication import Medication
 from api_fhir_r4.tests import MedicationTestMixin
+from api_fhir_r4.tests.mixin import ConvertToImisTestMixin, ConvertToFhirTestMixin, ConvertJsonToFhirTestMixin
 
 
-class MedicationConverterTestCase(MedicationTestMixin):
-
-    __TEST_MEDICATION_JSON_PATH = "/test/test_medication.json"
-
-    def setUp(self):
-        super(MedicationConverterTestCase, self).setUp()
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        self._test_medication_json_representation = open(dir_path + self.__TEST_MEDICATION_JSON_PATH).read()
-
-    def test_to_fhir_obj(self):
-        self.setUp()
-        imis_item = self.create_test_imis_instance()
-        fhir_medication = MedicationConverter.to_fhir_obj(imis_item)
-        self.verify_fhir_instance(fhir_medication)
-
-    def test_to_imis_obj(self):
-        self.setUp()
-        fhir_medication = self.create_test_fhir_instance()
-        imis_item = MedicationConverter.to_imis_obj(fhir_medication.dict(), None)
-        self.verify_imis_instance(imis_item)
-
-    def test_create_object_from_json(self):
-        self.setUp()
-        dict_medication = json.loads(self._test_medication_json_representation)
-        fhir_medication = Medication(**dict_medication)
-        self.verify_fhir_instance(fhir_medication)
+class MedicationConverterTestCase(MedicationTestMixin,
+                                  ConvertToImisTestMixin,
+                                  ConvertToFhirTestMixin,
+                                  ConvertJsonToFhirTestMixin):
+    converter = MedicationConverter
+    fhir_resource = Medication
+    json_repr = 'test/test_medication.json'

--- a/api_fhir_r4/tests/test_operationOutcomeConverter.py
+++ b/api_fhir_r4/tests/test_operationOutcomeConverter.py
@@ -1,25 +1,12 @@
-import json
-import os
-
 from api_fhir_r4.converters import OperationOutcomeConverter
+from api_fhir_r4.models import OperationOutcomeV2
 from api_fhir_r4.tests import OperationOutcomeTestMixin
+from api_fhir_r4.tests.mixin import ConvertToFhirTestMixin, ConvertJsonToFhirTestMixin
 
 
-class OperationOutcomeConverterTestCase(OperationOutcomeTestMixin):
-
-    __TEST_OUTCOME_JSON_PATH = "/test/test_outcome.json"
-
-    def setUp(self):
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        self._test_outcome_json_representation = open(dir_path + self.__TEST_OUTCOME_JSON_PATH).read()
-
-    def test_to_fhir_obj(self):
-        exc = self.create_test_imis_instance()
-        fhir_outcome = OperationOutcomeConverter.to_fhir_obj(exc)
-        self.verify_fhir_instance(fhir_outcome)
-
-    def test_fhir_object_to_json(self):
-        self.setUp()
-        fhir_outcome = self.create_test_fhir_instance().dict()
-        actual_representation = json.dumps(fhir_outcome)
-        self.assertEqual(self._test_outcome_json_representation, actual_representation)
+class OperationOutcomeConverterTestCase(OperationOutcomeTestMixin,
+                                        ConvertToFhirTestMixin,
+                                        ConvertJsonToFhirTestMixin):
+    converter = OperationOutcomeConverter
+    fhir_resource = OperationOutcomeV2
+    json_repr = 'test/test_outcome.json'

--- a/api_fhir_r4/tests/test_patientConverter.py
+++ b/api_fhir_r4/tests/test_patientConverter.py
@@ -1,38 +1,22 @@
-import json
-import os
 from unittest import mock
 
 from api_fhir_r4.converters import PatientConverter
 
 from fhir.resources.patient import Patient
 from api_fhir_r4.tests import PatientTestMixin
+from api_fhir_r4.tests.mixin import ConvertToFhirTestMixin, ConvertToImisTestMixin, ConvertJsonToFhirTestMixin
 
 
-class PatientConverterTestCase(PatientTestMixin):
-
-    __TEST_PATIENT_JSON_PATH = "/test/test_patient.json"
-
-    def setUp(self):
-        super(PatientConverterTestCase, self).setUp()
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        self._test_patient_json_representation = open(dir_path + self.__TEST_PATIENT_JSON_PATH).read()
-
-    def test_to_fhir_obj(self):
-        self.setUp()
-        imis_insuree = self.create_test_imis_instance()
-        fhir_patient = PatientConverter.to_fhir_obj(imis_insuree)
-        self.verify_fhir_instance(fhir_patient)
+class PatientConverterTestCase(PatientTestMixin,
+                               ConvertToFhirTestMixin,
+                               ConvertToImisTestMixin,
+                               ConvertJsonToFhirTestMixin):
+    converter = PatientConverter
+    fhir_resource = Patient
+    json_repr = 'test/test_patient.json'
 
     @mock.patch('insuree.models.Gender.objects')
     def test_to_imis_obj(self, mock_gender):
-        self.setUp()
         mock_gender.get.return_value = self._TEST_GENDER
+        super(PatientConverterTestCase, self).test_to_imis_obj()
 
-        fhir_patient = self.create_test_fhir_instance()
-        imis_insuree = PatientConverter.to_imis_obj(fhir_patient.dict(), None)
-        self.verify_imis_instance(imis_insuree)
-
-    def test_create_object_from_json(self):
-        dict_patient = json.loads(self._test_patient_json_representation)
-        fhir_patient = Patient(**dict_patient)
-        self.verify_fhir_instance(fhir_patient)

--- a/api_fhir_r4/tests/test_policyHolderOrganisationConverter.py
+++ b/api_fhir_r4/tests/test_policyHolderOrganisationConverter.py
@@ -1,13 +1,8 @@
 from api_fhir_r4.converters import PolicyHolderOrganisationConverter
+from api_fhir_r4.tests.mixin import ConvertToFhirTestMixin
 from api_fhir_r4.tests.mixin.policyHolderOrganisationTestMixin import PolicyHolderOrganisationTestMixin
 
 
-class PolicyHolderOrganisationConverterTestCase(PolicyHolderOrganisationTestMixin):
-    def setUp(self):
-        super(PolicyHolderOrganisationConverterTestCase, self).setUp()
-
-    def test_to_fhir_obj(self):
-        self.setUp()
-        imis_product = self.create_test_imis_instance()
-        fhir_insurance_plan = PolicyHolderOrganisationConverter.to_fhir_obj(imis_product)
-        self.verify_fhir_instance(fhir_insurance_plan)
+class PolicyHolderOrganisationConverterTestCase(PolicyHolderOrganisationTestMixin,
+                                                ConvertToFhirTestMixin):
+    converter = PolicyHolderOrganisationConverter

--- a/api_fhir_r4/tests/test_subscriptionConverter.py
+++ b/api_fhir_r4/tests/test_subscriptionConverter.py
@@ -1,0 +1,22 @@
+from fhir.resources.subscription import Subscription
+
+from api_fhir_r4.converters import SubscriptionConverter
+from api_fhir_r4.tests.mixin import ConvertToImisTestMixin, ConvertToFhirTestMixin, ConvertJsonToFhirTestMixin
+from api_fhir_r4.tests.mixin.SubscriptionTestMixin import SubscriptionTestMixin
+from api_fhir_r4.utils import TimeUtils
+
+
+class SubscriptionConverterTestCase(SubscriptionTestMixin,
+                                    ConvertToImisTestMixin,
+                                    ConvertToFhirTestMixin,
+                                    ConvertJsonToFhirTestMixin):
+    converter = SubscriptionConverter
+    fhir_resource = Subscription
+    json_repr = 'test/test_subscription.json'
+
+    def _load_json_repr(self):
+        json_repr = super(SubscriptionConverterTestCase, self)._load_json_repr()
+        json_repr['end'] = TimeUtils.str_iso_to_date(json_repr['end'])
+        return json_repr
+
+

--- a/api_fhir_r4/tests/test_subscriptionService.py
+++ b/api_fhir_r4/tests/test_subscriptionService.py
@@ -1,0 +1,68 @@
+from django.test import TestCase
+
+from api_fhir_r4.models import Subscription
+from api_fhir_r4.services import SubscriptionService
+from api_fhir_r4.utils import TimeUtils
+from core.models import User
+
+
+class SubscriptionServiceTest(TestCase):
+    user = None
+    service = None
+    create_payload = {
+        'status': 1,
+        'channel': 0,
+        'expiring': TimeUtils.str_iso_to_date('2021-01-01T01:02:03+01:00'),
+        'endpoint': 'https://subscriptiontest.com/test',
+        'headers': 'Authentication=Bearer 12351231',
+        'criteria': {
+            'resource_type': 'Patient',
+            'chfid__startswith': '1',
+        },
+    }
+
+    update_payload = {
+        'status': 0
+    }
+
+    @classmethod
+    def setUpTestData(cls):
+        if not User.objects.filter(username='admin_sub_service').exists():
+            User.objects.create_superuser(username='admin_sub_service', password='S\/pe®Pąßw0rd™')
+        cls.user = User.objects.filter(username='admin_sub_service').first()
+        cls.service = SubscriptionService(cls.user)
+
+    def test_create(self):
+        result = self.service.create(self.create_payload)
+        self.assertIsInstance(result, dict)
+        self.assertTrue(result['success'])
+        self.assertEqual('Ok'.lower(), result['message'].lower())
+        created_id = result['data']['id']
+        self.assertTrue(created_id)
+        queryset = Subscription.objects.filter(id=created_id)
+        self.assertEqual(queryset.count(), 1)
+
+    def test_update(self):
+        result_create = self.service.create(self.create_payload)
+        created_id = result_create['data']['id']
+        update_payload = {**self.update_payload, **{'id': created_id}}
+        result = self.service.update(update_payload)
+        self.assertIsInstance(result, dict)
+        self.assertTrue(result['success'])
+        self.assertEqual('Ok'.lower(), result['message'].lower())
+        changed_fields = {key: result['data'][key] for key in result['data'] if key in update_payload}
+        self.assertDictEqual(update_payload, changed_fields)
+        queryset = Subscription.objects.filter(id=created_id)
+        self.assertEqual(queryset.count(), 1)
+
+    def test_delete(self):
+        result_create = self.service.create(self.create_payload)
+        created_id = result_create['data']['id']
+        delete_payload = {'id': created_id}
+        result = self.service.delete(delete_payload)
+        self.assertTrue(result['success'])
+        self.assertEqual('Ok'.lower(), result['message'].lower())
+        queryset = Subscription.objects.filter(id=created_id, is_deleted=True)
+        self.assertEqual(queryset.count(), 1)
+        queryset = Subscription.objects.filter(id=created_id, is_deleted=False)
+        self.assertEqual(queryset.count(), 0)


### PR DESCRIPTION
[https://openimis.atlassian.net/browse/OPL-72](https://openimis.atlassian.net/browse/OPL-72)

Changes:
- Added Service, Converter and Endpoint test for Subscription resource
- Added datetime conversion to `SubscriptionConverter` and removed it form serializer
- Moved identical converter test code to mixins