### PR TITLE
OPL-92: Enhance the way subscription criteria store the resource type

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,5 +201,44 @@ Example of response ([mapping description](https://openimis.atlassian.net/wiki/s
 }
 ```
 
+## Subscriptions
+
+FHIR API R4 module allows users to define subscriptions and receive notifications when new resources are created or 
+updated. Currently, supported resources are:
+- Patient
+- Organisation (only of `bus` or HealthFacility type)
+- Invoice (All Bill and Invoice types defined in `invoiceMapping.py`)
+
+To use the subscription feature a user is required to have related subscription permissions and read permission for subscribed 
+resource. To create a subscription the following payload should be sent to `/Subscription/` endpoint:
+```JSON
+{
+    "status": "active",
+    "end": "2030-01-01T00:00:00Z",
+    "reason": "Invoice",
+    "criteria": "Invoice?resourceType=policy",
+    "channel": {
+        "type": "rest-hook",
+        "endpoint": "http://example.com/path",
+        "header": [
+            "{\"example\": \"1234\"}"
+        ]
+    }
+}
+```
+
+Explanation of the payload:
+- `status` - required to be `"active"`
+- `end` - subscription expiration time (required to have datetime information, `Z` for UTC)
+- `reason` - required to match subscribed resource name
+- `criteria` - allows to filter resources that should be included in a notification (should match GET arguments format). 
+  - To subscribe all resources of a given name, leave the same as `reason`
+  - To subscribe all resources of a given type, include `resourceType` argument and specify a type. To subscribe multiple types of a given resource (but not all), create multiple subscriptions
+  - You can specify additional filtering arguments after that. Currently, the format should match queryset filter keyword arguments of the underlying IMIS model
+- `channel` - specify the target for notifications
+  - `type` - currently the only supported type is `rest-hook`
+  - `endpoint` - url to send notifications to (should allow POST method)
+  - `header` - serialized json string specifying additional headers to be included in POST request, beside the standard HTTP headers (i.e. `Authentication` header with bearer token should be `"{\"Authentication\": \"bearer abcdef0123456789\"}"`). To not include any headers leave as `"{}"`.
+
 # Dependencies
 All required dependencies can be found in the [setup.py](https://github.com/openimis/openimis-be-api_fhir_r4_py/blob/master/setup.py) file.

--- a/api_fhir_r4/configurations/R4SubscriptionConfig.py
+++ b/api_fhir_r4/configurations/R4SubscriptionConfig.py
@@ -35,3 +35,13 @@ class R4SubscriptionConfig(SubscriptionConfiguration):
     @classmethod
     def get_fhir_subscription_status_active(cls):
         return cls.get_config_attribute('R4_fhir_subscription_config').get('fhir_sub_status_active', 'active')
+
+    @classmethod
+    def get_fhir_sub_criteria_key_resource(cls):
+        return cls.get_config_attribute('R4_fhir_subscription_config').get('get_fhir_sub_criteria_key_resource',
+                                                                           'resource')
+
+    @classmethod
+    def get_fhir_sub_criteria_key_resource_type(cls):
+        return cls.get_config_attribute('R4_fhir_subscription_config').get('get_fhir_sub_criteria_key_resource_type',
+                                                                           'resourceType')

--- a/api_fhir_r4/configurations/R4SubscriptionConfig.py
+++ b/api_fhir_r4/configurations/R4SubscriptionConfig.py
@@ -44,4 +44,4 @@ class R4SubscriptionConfig(SubscriptionConfiguration):
     @classmethod
     def get_fhir_sub_criteria_key_resource_type(cls):
         return cls.get_config_attribute('R4_fhir_subscription_config').get('get_fhir_sub_criteria_key_resource_type',
-                                                                           'resourceType')
+                                                                           'resource_type')

--- a/api_fhir_r4/configurations/__init__.py
+++ b/api_fhir_r4/configurations/__init__.py
@@ -547,6 +547,14 @@ class SubscriptionConfiguration(BaseConfiguration):
     def get_fhir_subscription_status_active(cls):
         raise NotImplementedError('`get_fhir_subscription_status_active()` must be implemented.')
 
+    @classmethod
+    def get_fhir_sub_criteria_key_resource(cls):
+        raise NotImplementedError('`get_fhir_sub_criteria_key_resource()` must be implemented.')
+
+    @classmethod
+    def get_fhir_sub_criteria_key_resource_type(cls):
+        raise NotImplementedError('`get_fhir_sub_criteria_key_resource_type()` must be implemented.')
+
 
 class BaseApiFhirConfiguration(BaseConfiguration):  # pragma: no cover
 

--- a/api_fhir_r4/converters/contractConverter.py
+++ b/api_fhir_r4/converters/contractConverter.py
@@ -42,7 +42,7 @@ class ContractConverter(BaseFHIRConverter, ReferenceConverterMixin):
         cls.build_contract_status(fhir_contract, imis_policy)
         cls.build_contract_state(fhir_contract, imis_policy)
         return fhir_contract
-    
+
     @classmethod
     def to_imis_obj(cls,fhir_contract, audit_user_id):
         errors = []
@@ -237,7 +237,7 @@ class ContractConverter(BaseFHIRConverter, ReferenceConverterMixin):
 
         offer.party = [offer_party]
         contract_term_offer.offer = offer
-        
+
     @classmethod
     def build_contract_status(cls, contract, imis_policy):
         if f"{imis_policy.status}" in ContractStatus.contract_status:
@@ -300,14 +300,13 @@ class ContractConverter(BaseFHIRConverter, ReferenceConverterMixin):
                     if asset.period:
                         for period in asset.period:
                             if not cls.valid_condition(period.start is None, _('Missing  `period start` attribute'),errors):
-                                imis_policy.start_date = TimeUtils.str_to_date(period.start) 
-                                imis_policy.enroll_date = TimeUtils.str_to_date(period.start) 
+                                imis_policy.start_date = TimeUtils.str_to_date(period.start)
+                                imis_policy.enroll_date = TimeUtils.str_to_date(period.start)
                             if not cls.valid_condition(period.end is None, _('Missing  `period end` attribute'),errors):
-                                imis_policy.expiry_date = TimeUtils.str_to_date(period.end) 
-                                imis_policy.validity_to = TimeUtils.str_to_date(period.end)
+                                imis_policy.expiry_date = TimeUtils.str_to_date(period.end)
                     else:
                         cls.valid_condition(not asset.period, _('Missing  `period` attribute'),errors)
-                        
+
     @classmethod
     def build_imis_useperiod(cls, imis_policy,fhir_contract,errors):
         for term in  fhir_contract:
@@ -318,10 +317,10 @@ class ContractConverter(BaseFHIRConverter, ReferenceConverterMixin):
                             if not cls.valid_condition(period.start is None, _('Missing  `usePeriod start` attribute'),errors):
                                 imis_policy.effective_date = TimeUtils.str_to_date(period.start)
                             if not cls.valid_condition(period.end is None, _('Missing  `usePeriod end` attribute'),errors):
-                                imis_policy.expiry_date = TimeUtils.str_to_date(period.end) 
+                                imis_policy.expiry_date = TimeUtils.str_to_date(period.end)
                     else:
                         cls.valid_condition(not asset.usePeriod, _('Missing  `usePeriod` attribute'),errors)
-    
+
     @classmethod
     def build_imis_status(cls, fhir_contract, imis_policy,errors):
         if fhir_contract.status:
@@ -379,12 +378,12 @@ class ContractConverter(BaseFHIRConverter, ReferenceConverterMixin):
                             reference = signer.party.reference.split("/", 2)
                             imis_policy.officer = Officer.objects.get(uuid=reference[1])
                         else:
-                            pass     
+                            pass
                 else:
                     cls.valid_condition(signer.type is None, _('Missing  `type` attribute'),errors)
         else:
             cls.valid_condition(not fhir_contract.signer, _('Missing  `signer` attribute'),errors)
-            
+
     @classmethod
     def build_imis_insurees(cls,fhir_contract,imis_policy,errors):
         if fhir_contract.term:
@@ -411,7 +410,7 @@ class ContractConverter(BaseFHIRConverter, ReferenceConverterMixin):
                             cls.valid_condition(not asset.context, _('Missing  `context` attribute'),errors)
                 else:
                     cls.valid_condition(not term.asset, _('Missing  `asset` attribute'),errors)
-                        
+
         else:
             cls.valid_condition(not fhir_contract, _('Missing  `term` attribute'),errors)
 
@@ -429,15 +428,15 @@ class ContractConverter(BaseFHIRConverter, ReferenceConverterMixin):
                                         imis_policy.product = Product.objects.get(uuid=reference[1])
                                 if item.net is not None:
                                     if item.net.value is not None:
-                                        imis_policy.value = item.net.value                                                       
+                                        imis_policy.value = item.net.value
                         else:
                             cls.valid_condition(not asset.valuedItem, _('Missing  `valuedItem` attribute'), errors)
                 else:
                     cls.valid_condition(not term.asset, _('Missing  `asset` attribute'), errors)
-                        
+
         else:
             cls.valid_condition(not fhir_contract, _('Missing  `term` attribute'), errors)
-                        
+
     @classmethod
     def build_imis_state(cls,fhir_contract, imis_policy, errors):
         if fhir_contract.legalState:
@@ -447,7 +446,7 @@ class ContractConverter(BaseFHIRConverter, ReferenceConverterMixin):
                 elif fhir_contract.legalState.text == R4CoverageConfig.get_status_renewed_code():
                     imis_policy.stage = ContractState.imis_map_stage(R4CoverageConfig.get_status_renewed_code(), imis_policy)
                 else:
-                    pass       
+                    pass
         else:
             cls.valid_condition(fhir_contract.legalState is None, _('Missing  `legalState` attribute'), errors)
 

--- a/api_fhir_r4/defaultConfig.py
+++ b/api_fhir_r4/defaultConfig.py
@@ -183,6 +183,8 @@ DEFAULT_CFG = {
         "fhir_sub_delete_perms": ['158004'],
         "fhir_sub_channel_rest_hook": "rest-hook",
         "fhir_sub_status_off": "off",
-        "fhir_sub_status_active": "active"
+        "fhir_sub_status_active": "active",
+        "get_fhir_sub_criteria_key_resource": "resource",
+        "get_fhir_sub_criteria_key_resource_type": "resource_type"
     }
 }

--- a/api_fhir_r4/migrations/0004_update_subscription_criteria.py
+++ b/api_fhir_r4/migrations/0004_update_subscription_criteria.py
@@ -1,0 +1,38 @@
+import logging
+
+from django.db import migrations
+
+logger = logging.getLogger(__name__)
+
+
+def update_subscription_criteria(apps, schema_editor):
+    resource_type_map = {
+        'Invoice': 'Invoice',
+        'Bill': 'Invoice',
+        'Patient': 'Patient',
+        'Organisation': 'Organisation'
+    }
+
+    subscription_model = apps.get_model('api_fhir_r4', 'Subscription')
+    entries_to_update = subscription_model.objects\
+        .exclude(criteria__jsoncontainskey='resource')\
+        .filter(criteria__jsoncontainskey='resource_type')\
+        .all()
+    for subscription in entries_to_update:
+        resource = subscription.criteria.pop('resource_type')
+        if resource in resource_type_map:
+            subscription.criteria['resource'] = resource_type_map[resource]
+            subscription.save()
+        else:
+            logger.warning(f'Subscription of unexpected type - {resource}')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api_fhir_r4', '0003_auto_20220313_1634'),
+    ]
+
+    operations = [
+        migrations.RunPython(update_subscription_criteria, migrations.RunPython.noop)
+    ]

--- a/api_fhir_r4/subscriptions/subscriptionConverter.py
+++ b/api_fhir_r4/subscriptions/subscriptionConverter.py
@@ -3,6 +3,7 @@ from urllib import parse
 
 from fhir.resources.subscription import Subscription as FHIRSubscription
 
+from api_fhir_r4.configurations import R4SubscriptionConfig
 from api_fhir_r4.converters import BaseFHIRConverter, ReferenceConverterMixin
 from api_fhir_r4.exceptions import FHIRException
 from api_fhir_r4.mapping.subscriptionMapping import SubscriptionChannelMapping, SubscriptionStatusMapping
@@ -63,14 +64,18 @@ class SubscriptionConverter(BaseFHIRConverter):
 
     @classmethod
     def _build_fhir_reason(cls, fhir_subscription, imis_subscription):
-        fhir_subscription['reason'] = imis_subscription.criteria['resource_type']
+        fhir_subscription['reason'] = \
+            imis_subscription.criteria[R4SubscriptionConfig.get_fhir_sub_criteria_key_resource()]
 
     @classmethod
     def _build_fhir_criteria(cls, fhir_subscription, imis_subscription):
         criteria = deepcopy(imis_subscription.criteria)
-        resource = criteria.pop('resource_type')
-        fhir_subscription['criteria'] = parse.urlunparse(
-            ('', '', resource, '', parse.urlencode(criteria, doseq=True), ''))
+        resource = criteria.pop(R4SubscriptionConfig.get_fhir_sub_criteria_key_resource())
+        resource_type = criteria.pop(R4SubscriptionConfig.get_fhir_sub_criteria_key_resource_type(), None)
+        if resource_type:
+            criteria['resourceType'] = resource_type
+        fhir_subscription['criteria'] = \
+            parse.urlunparse(('', '', resource, '', parse.urlencode(criteria, doseq=True), ''))
 
     @classmethod
     def _build_fhir_error(cls, fhir_subscription, imis_subscription):
@@ -126,7 +131,10 @@ class SubscriptionConverter(BaseFHIRConverter):
         if fhir_subscription.criteria:
             parsed_criteria = parse.urlparse(fhir_subscription.criteria)
             imis_criteria = dict(parse.parse_qsl(parsed_criteria.query))
-            imis_criteria['resource_type'] = parsed_criteria.path.strip('/')
+            resource_type = imis_criteria.pop('resourceType', None)
+            if resource_type:
+                imis_criteria[R4SubscriptionConfig.get_fhir_sub_criteria_key_resource_type()] = resource_type
+            imis_criteria[R4SubscriptionConfig.get_fhir_sub_criteria_key_resource()] = parsed_criteria.path.strip('/')
             imis_subscription['criteria'] = imis_criteria
             cls._validate_fhir_reason(imis_subscription, fhir_subscription)
         else:
@@ -137,7 +145,8 @@ class SubscriptionConverter(BaseFHIRConverter):
         # there is no imis reason so validation only
         if 'criteria' not in imis_subscription:
             raise FHIRException(cls._error_invalid_attr % {'attr': 'criteria'})
-        if fhir_subscription.reason.lower() != imis_subscription['criteria']['resource_type'].lower():
+        if fhir_subscription.reason.lower() \
+                != imis_subscription['criteria'][R4SubscriptionConfig.get_fhir_sub_criteria_key_resource()].lower():
             raise FHIRException(cls._error_invalid_attr % {'attr': 'reason'})
 
     @classmethod
@@ -148,7 +157,8 @@ class SubscriptionConverter(BaseFHIRConverter):
 
     @classmethod
     def _build_imis_channel_type(cls, imis_subscription, fhir_subscription):
-        if fhir_subscription.channel.type and fhir_subscription.channel.type in SubscriptionChannelMapping.to_imis_channel:
+        if fhir_subscription.channel.type \
+                and fhir_subscription.channel.type in SubscriptionChannelMapping.to_imis_channel:
             imis_subscription['channel'] = SubscriptionChannelMapping.to_imis_channel[fhir_subscription.channel.type]
         else:
             raise FHIRException(cls._error_invalid_attr % {'attr': 'channel.type'})

--- a/api_fhir_r4/subscriptions/subscriptionConverter.py
+++ b/api_fhir_r4/subscriptions/subscriptionConverter.py
@@ -1,3 +1,4 @@
+import datetime
 from copy import deepcopy
 from urllib import parse
 
@@ -60,7 +61,8 @@ class SubscriptionConverter(BaseFHIRConverter):
 
     @classmethod
     def _build_fhir_end(cls, fhir_subscription, imis_subscription):
-        fhir_subscription['end'] = imis_subscription.expiring.astimezone()
+        date = imis_subscription.expiring.astimezone().isoformat()
+        fhir_subscription['end'] = date
 
     @classmethod
     def _build_fhir_reason(cls, fhir_subscription, imis_subscription):
@@ -122,7 +124,8 @@ class SubscriptionConverter(BaseFHIRConverter):
     @classmethod
     def _build_imis_end(cls, imis_subscription, fhir_subscription):
         if fhir_subscription.end:
-            imis_subscription['expiring'] = TimeUtils.str_iso_to_date(fhir_subscription.end)
+            imis_subscription['expiring'] = TimeUtils.str_iso_to_date(fhir_subscription.end).astimezone(
+                datetime.timezone.utc)
         else:
             raise FHIRException(cls._error_invalid_attr % {'attr': 'end'})
 

--- a/api_fhir_r4/tests/mixin/SubscriptionTestMixin.py
+++ b/api_fhir_r4/tests/mixin/SubscriptionTestMixin.py
@@ -11,7 +11,7 @@ class SubscriptionTestMixin(GenericTestMixin):
     _TEST_SUB_IMIS_EXPIRING = '2020-01-01T00:00:00+00:00'
 
     _TEST_SUB_IMIS_CRITERIA = {
-        'resource_type': 'Patient',
+        'resource': 'Patient',
         'chfid__startswith': '0'
     }
     _TEST_SUB_IMIS_STATUS = 1

--- a/api_fhir_r4/views/fhir/subscription.py
+++ b/api_fhir_r4/views/fhir/subscription.py
@@ -9,6 +9,7 @@ from api_fhir_r4.subscriptions import SubscriptionSerializer
 from api_fhir_r4.services import SubscriptionService
 from api_fhir_r4.subscriptions.subscriptionSerializer import SubscriptionSerializerSchema
 from api_fhir_r4.views.fhir.base import BaseFHIRView
+from api_fhir_r4.views.filters import DateUpdatedRequestParameterFilter
 
 
 @extend_schema_view(
@@ -30,9 +31,12 @@ from api_fhir_r4.views.fhir.base import BaseFHIRView
 class SubscriptionViewSet(BaseFHIRView, ModelViewSet):
     _error_while_deleting = 'Error while deleting a subscription: %(msg)s'
     serializer_class = SubscriptionSerializer
-    queryset = Subscription.objects.filter(is_deleted=False).order_by('date_created')
     http_method_names = ('get', 'post', 'put', 'delete')
     permission_classes = (FHIRApiSubscriptionPermissions,)
+
+    def get_queryset(self):
+        queryset = Subscription.objects.filter(is_deleted=False).order_by('date_created')
+        return DateUpdatedRequestParameterFilter(self.request).filter_queryset(queryset)
 
     def perform_destroy(self, instance):
         if not self.check_if_owner(self.request.user, instance):


### PR DESCRIPTION
[https://openimis.atlassian.net/browse/OPL-92](https://openimis.atlassian.net/browse/OPL-92)

Changes:
- Updated subscription `criteria` definition to split `resource` and `resource type`
- Added migration to update existing subscriptions
- Updated all endpoint components to reflect the new criteria
- Updated `SubscriptionCriteriaFilter` to include both resource and resource type in initial subscription fetch
- Added README entry for subscription notification feature