### PR TITLE
OE0-106: Fixed patient address

### DIFF
--- a/api_fhir_r4/tests/mixin/patientTestMixin.py
+++ b/api_fhir_r4/tests/mixin/patientTestMixin.py
@@ -215,7 +215,7 @@ class PatientTestMixin(GenericTestMixin):
         extension = Extension.construct()
         extension.url = f"{GeneralConfiguration.get_system_base_url()}StructureDefinition/address-location-reference"
         reference_location = Reference.construct()
-        reference_location.reference = F"Location/{imis_location.name}-village"
+        reference_location.reference = F"Location/{imis_location.uuid}"
         extension.valueReference = reference_location
         family_address.extension.append(extension)
 
@@ -313,7 +313,6 @@ class PatientTestMixin(GenericTestMixin):
                 self.assertEqual(self._TEST_PHONE, telecom.value)
             elif telecom.system == "email":
                 self.assertEqual(self._TEST_EMAIL, telecom.value)
-        self.assertEqual(2, len(fhir_obj.address))
         for address in fhir_obj.address:
             self.assertTrue(isinstance(address, Address))
             if address.use == "home":


### PR DESCRIPTION
Part of [OE0-106](https://openimis.atlassian.net/browse/OE0-106)

**Changes:**
 - It's no longer possible to create insuree with empty chf_id.
- current_address is text field in Patient's current_village address. 
- If patient is without family, home address is used as family location. 
- If patient is part of family but isHead is true then exception is raised (previously new family not related to previous one was created). 
- If general practitioner is provided in POST payload, it's used as patient's health facility.

Note: Currently it is not possible to specify current_address without also specifying current_village.