### PR TITLE
OE0-107: modified validity of permissions in multizerialized classes

### DIFF
--- a/api_fhir_r4/permissions.py
+++ b/api_fhir_r4/permissions.py
@@ -1,4 +1,5 @@
 from api_fhir_r4.configurations import R4SubscriptionConfig
+from core.apps import CoreConfig
 from claim.apps import ClaimConfig
 from insuree.apps import InsureeConfig
 from location.apps import LocationConfig
@@ -49,11 +50,19 @@ class FHIRApiCommunicationRequestPermissions(FHIRApiPermissions):
 
 
 class FHIRApiPractitionerPermissions(FHIRApiPermissions):
-    permissions_get = ClaimConfig.gql_query_claim_admins_perms
-    permissions_post = ClaimConfig.gql_query_claim_admins_perms
-    permissions_put = ClaimConfig.gql_query_claim_admins_perms
-    permissions_patch = ClaimConfig.gql_query_claim_admins_perms
-    permissions_delete = ClaimConfig.gql_query_claim_admins_perms
+    permissions_get = CoreConfig.gql_query_claim_administrator_perms
+    permissions_post = CoreConfig.gql_mutation_create_claim_administrator_perms
+    permissions_put = CoreConfig.gql_mutation_update_claim_administrator_perms
+    permissions_patch = CoreConfig.gql_mutation_update_claim_administrator_perms
+    permissions_delete = CoreConfig.gql_mutation_delete_claim_administrator_perms
+
+
+class FHIRApiPractitionerOfficerPermissions(FHIRApiPermissions):
+    permissions_get = CoreConfig.gql_query_enrolment_officers_perms
+    permissions_post = CoreConfig.gql_mutation_create_enrolment_officers_perms
+    permissions_put = CoreConfig.gql_mutation_update_enrolment_officers_perms
+    permissions_patch = CoreConfig.gql_mutation_update_enrolment_officers_perms
+    permissions_delete = CoreConfig.gql_mutation_delete_enrolment_officers_perms
 
 
 class FHIRApiCoverageEligibilityRequestPermissions(FHIRApiPermissions):
@@ -78,6 +87,14 @@ class FHIRApiHFPermissions(FHIRApiPermissions):
     permissions_put = LocationConfig.gql_mutation_create_health_facilities_perms
     permissions_patch = LocationConfig.gql_mutation_create_health_facilities_perms
     permissions_delete = LocationConfig.gql_mutation_delete_health_facilities_perms
+
+
+class FHIRApiInsuranceOrganizationPermissions(FHIRApiPermissions):
+    permissions_get = LocationConfig.gql_query_health_facilities_perms
+    permissions_post = []
+    permissions_put = []
+    permissions_patch = []
+    permissions_delete = []
 
 
 class FHIRApiInsureePermissions(FHIRApiPermissions):
@@ -150,6 +167,14 @@ class FHIRApiInvoicePermissions(FHIRApiPermissions):
     permissions_put = InvoiceConfig.gql_invoice_update_perms
     permissions_patch = InvoiceConfig.gql_invoice_update_perms
     permissions_delete = InvoiceConfig.gql_invoice_delete_perms
+
+
+class FHIRApiBillPermissions(FHIRApiPermissions):
+    permissions_get = InvoiceConfig.gql_bill_search_perms
+    permissions_post = InvoiceConfig.gql_bill_create_perms
+    permissions_put = InvoiceConfig.gql_bill_update_perms
+    permissions_patch = InvoiceConfig.gql_bill_update_perms
+    permissions_delete = InvoiceConfig.gql_bill_delete_perms
 
 
 class FHIRApiSubscriptionPermissions(FHIRApiPermissions):

--- a/api_fhir_r4/tests/test_api_authorization.py
+++ b/api_fhir_r4/tests/test_api_authorization.py
@@ -98,7 +98,7 @@ class AuthorizationAPITests(GenericFhirAPITestMixin, APITestCase, LogInMixin):
         response_json = response.json()
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(
-            response_json["issue"][0]["details"]["text"], "You do not have permission to perform this action."
+            response_json["issue"][0]["details"]["text"], "User unauthorized for any of the resourceType available in the view."
         )
 
     def test_get_should_required_login(self):

--- a/api_fhir_r4/views/fhir/invoice.py
+++ b/api_fhir_r4/views/fhir/invoice.py
@@ -1,12 +1,24 @@
 from rest_framework.request import Request
 
 from api_fhir_r4.mapping.invoiceMapping import InvoiceTypeMapping, BillTypeMapping
-from api_fhir_r4.mixins import MultiIdentifierRetrieveManySerializersMixin, MultiIdentifierRetrieverMixin
-from api_fhir_r4.model_retrievers import CodeIdentifierModelRetriever, DatabaseIdentifierModelRetriever, \
+from api_fhir_r4.mixins import (
+    MultiIdentifierRetrieveManySerializersMixin,
+    MultiIdentifierRetrieverMixin
+)
+from api_fhir_r4.model_retrievers import (
+    CodeIdentifierModelRetriever,
+    DatabaseIdentifierModelRetriever,
     UUIDIdentifierModelRetriever
+)
 from api_fhir_r4.multiserializer import modelViewset
-from api_fhir_r4.permissions import FHIRApiInvoicePermissions
-from api_fhir_r4.serializers import InvoiceSerializer, BillSerializer
+from api_fhir_r4.permissions import (
+    FHIRApiInvoicePermissions,
+    FHIRApiBillPermissions
+)
+from api_fhir_r4.serializers import (
+    InvoiceSerializer,
+    BillSerializer
+)
 from api_fhir_r4.views.fhir.base import BaseMultiserializerFHIRView
 from api_fhir_r4.views.filters import DateUpdatedRequestParameterFilter
 from invoice.models import Bill
@@ -25,7 +37,7 @@ class InvoiceViewSet(BaseMultiserializerFHIRView,
             InvoiceSerializer:
                 (self._invoice_queryset(), self._invoice_serializer_validator, (FHIRApiInvoicePermissions,)),
             BillSerializer:
-                (self._bill_queryset(), self._bill_serializer_validator, (FHIRApiInvoicePermissions,))
+                (self._bill_queryset(), self._bill_serializer_validator, (FHIRApiBillPermissions,))
         }
 
     @classmethod

--- a/api_fhir_r4/views/fhir/practitioner.py
+++ b/api_fhir_r4/views/fhir/practitioner.py
@@ -2,11 +2,23 @@ import logging
 
 from rest_framework.request import Request
 
-from api_fhir_r4.mixins import MultiIdentifierRetrieveManySerializersMixin, MultiIdentifierRetrieverMixin
-from api_fhir_r4.model_retrievers import UUIDIdentifierModelRetriever, CodeIdentifierModelRetriever
+from api_fhir_r4.mixins import (
+    MultiIdentifierRetrieveManySerializersMixin,
+    MultiIdentifierRetrieverMixin
+)
+from api_fhir_r4.model_retrievers import (
+    UUIDIdentifierModelRetriever,
+    CodeIdentifierModelRetriever
+)
 from api_fhir_r4.multiserializer import modelViewset
-from api_fhir_r4.permissions import FHIRApiPractitionerPermissions
-from api_fhir_r4.serializers import ClaimAdminPractitionerSerializer, EnrolmentOfficerPractitionerSerializer
+from api_fhir_r4.permissions import (
+    FHIRApiPractitionerPermissions,
+    FHIRApiPractitionerOfficerPermissions
+)
+from api_fhir_r4.serializers import (
+    ClaimAdminPractitionerSerializer,
+    EnrolmentOfficerPractitionerSerializer
+)
 from api_fhir_r4.views.fhir.base import BaseMultiserializerFHIRView
 from api_fhir_r4.views.filters import ValidityFromRequestParameterFilter
 from claim.models import ClaimAdmin
@@ -20,7 +32,6 @@ class PractitionerViewSet(BaseMultiserializerFHIRView,
                           modelViewset.MultiSerializerModelViewSet,
                           MultiIdentifierRetrieveManySerializersMixin, MultiIdentifierRetrieverMixin):
     retrievers = [UUIDIdentifierModelRetriever, CodeIdentifierModelRetriever]
-    permission_classes = (FHIRApiPractitionerPermissions,)
 
     lookup_field = 'identifier'
 
@@ -30,7 +41,7 @@ class PractitionerViewSet(BaseMultiserializerFHIRView,
             ClaimAdminPractitionerSerializer:
                 (self._ca_queryset(), self._ca_serializer_validator, (FHIRApiPractitionerPermissions,)),
             EnrolmentOfficerPractitionerSerializer:
-                (self._eo_queryset(), self._eo_serializer_validator, (FHIRApiPractitionerPermissions,)),
+                (self._eo_queryset(), self._eo_serializer_validator, (FHIRApiPractitionerOfficerPermissions,)),
         }
 
     @classmethod

--- a/api_fhir_r4/views/fhir/practitioner_role.py
+++ b/api_fhir_r4/views/fhir/practitioner_role.py
@@ -2,12 +2,23 @@ import logging
 
 from rest_framework.request import Request
 
-from api_fhir_r4.mixins import MultiIdentifierRetrieveManySerializersMixin, MultiIdentifierRetrieverMixin
-from api_fhir_r4.model_retrievers import CodeIdentifierModelRetriever, UUIDIdentifierModelRetriever
+from api_fhir_r4.mixins import (
+    MultiIdentifierRetrieveManySerializersMixin,
+    MultiIdentifierRetrieverMixin
+)
+from api_fhir_r4.model_retrievers import (
+    CodeIdentifierModelRetriever,
+    UUIDIdentifierModelRetriever
+)
 from api_fhir_r4.multiserializer import modelViewset
-from api_fhir_r4.permissions import FHIRApiPractitionerPermissions
-from api_fhir_r4.serializers import ClaimAdminPractitionerRoleSerializer, \
+from api_fhir_r4.permissions import (
+    FHIRApiPractitionerPermissions,
+    FHIRApiPractitionerOfficerPermissions
+)
+from api_fhir_r4.serializers import (
+    ClaimAdminPractitionerRoleSerializer,
     EnrolmentOfficerPractitionerRoleSerializer
+)
 from api_fhir_r4.views.fhir.base import BaseMultiserializerFHIRView
 from api_fhir_r4.views.filters import ValidityFromRequestParameterFilter
 from claim.models import ClaimAdmin
@@ -28,7 +39,7 @@ class PractitionerRoleViewSet(BaseMultiserializerFHIRView,
             ClaimAdminPractitionerRoleSerializer:
                 (self._ca_queryset(), self._ca_serializer_validator, (FHIRApiPractitionerPermissions,)),
             EnrolmentOfficerPractitionerRoleSerializer:
-                (self._eo_queryset(), self._eo_serializer_validator, (FHIRApiPractitionerPermissions,)),
+                (self._eo_queryset(), self._eo_serializer_validator, (FHIRApiPractitionerOfficerPermissions,)),
         }
 
     @classmethod


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OE0-107

Changes: 
- added new permission classes 
- modified views by updating permission classes in multizerialized classes
- fix bug in InsuranceOrganization when we don't have pemissions to fetch InsuranceOrganization
- minor code refactor in imports

Note: In the future we can rename some names of permission classes. 