### PR TITLE
OTC-843 modular IMIS: wrong reaction on duplicated underwriting of a policy

### DIFF
--- a/.github/workflows/openmis-module-test.yml
+++ b/.github/workflows/openmis-module-test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     services:
       mssql:
         image: mcr.microsoft.com/mssql/server:2017-latest

--- a/api_fhir_r4/signals.py
+++ b/api_fhir_r4/signals.py
@@ -44,8 +44,9 @@ def bind_service_signals():
         from invoice.models import Bill, Invoice
 
         def on_bill_create(**kwargs):
-            if kwargs.get('result', {}).get('success', False):
-                model_uuid = kwargs['result']['data']['uuid']
+            result = kwargs.get('result', {})
+            if result and result.get('success', False):
+                model_uuid = result['data']['uuid']
                 try:
                     model = Bill.objects.get(uuid=model_uuid)
                     notify_subscribers(model, BillInvoiceConverter(), 'Invoice',
@@ -56,8 +57,9 @@ def bind_service_signals():
                     logger.debug(traceback.format_exc())
 
         def on_invoice_create(**kwargs):
-            if kwargs.get('result', {}).get('success', False):
-                model_uuid = kwargs['result']['data']['uuid']
+            result = kwargs.get('result', {})
+            if result and result.get('success', False):
+                model_uuid = result['data']['uuid']
                 try:
                     model = Invoice.objects.get(uuid=model_uuid)
                     notify_subscribers(model, InvoiceConverter(), 'Invoice',


### PR DESCRIPTION
[https://openimis.atlassian.net/browse/OTC-843](https://openimis.atlassian.net/browse/OTC-843)
Changes:
- Fixed bill/invoice subscription hooks when the result value is None
- Updated ubuntu to 20.04 in CI workflow