### PR TITLE
Fix medication package conversion bug

### DIFF
--- a/api_fhir_r4/converters/medicationConverter.py
+++ b/api_fhir_r4/converters/medicationConverter.py
@@ -17,6 +17,7 @@ from api_fhir_r4.exceptions import FHIRException
 from api_fhir_r4.utils import DbManagerUtils
 from api_fhir_r4.configurations import GeneralConfiguration
 import core
+import re
 
 
 class MedicationConverter(BaseFHIRConverter, ReferenceConverterMixin):
@@ -96,16 +97,6 @@ class MedicationConverter(BaseFHIRConverter, ReferenceConverterMixin):
             fhir_medication.form = codeable
 
     @classmethod
-    def split_package_form(cls, form):
-        form = form.lstrip()
-        if " " not in form:
-            return form
-        if " " in form:
-            form = form.split(' ', 1)
-            form = form[1]
-            return form
-
-    @classmethod
     def build_fhir_package_amount(cls, fhir_medication, imis_medication):
         # TODO - Split medical item ItemPackage into ItemForm and ItemAmount => openIMIS side
         if imis_medication.package:
@@ -119,12 +110,10 @@ class MedicationConverter(BaseFHIRConverter, ReferenceConverterMixin):
     @classmethod
     def split_package_amount(cls, amount):
         amount = amount.lstrip()
-        if " " not in amount:
-            return None
-        if " " in amount:
-            amount = amount.split(' ', 1)
-            amount = amount[0]
-            return int(amount)
+        try:
+            return int(re.sub("[^0-9]","",amount))
+        except ValueError as exception:
+            return 0
 
     @classmethod
     def build_fhir_medication_extension(cls, fhir_medication, imis_medication):

--- a/api_fhir_r4/tests/mixin/medicationTestMixin.py
+++ b/api_fhir_r4/tests/mixin/medicationTestMixin.py
@@ -1,4 +1,5 @@
 import decimal
+import re
 
 from medical.models import Item
 
@@ -23,7 +24,7 @@ class MedicationTestMixin(GenericTestMixin):
     _TEST_MEDICATION_CODE = "TEST1"
     _TEST_MEDICATION_NAME = "TEST TABS 300MG"
     _TEST_MEDICATION_TYPE = "D"
-    _TEST_MEDICATION_PACKAGE = "1000 TABLETS"
+    _TEST_MEDICATION_PACKAGE = "1000TABLETS"
     _TEST_MEDICATION_PRICE = 5.99
     _TEST_MEDICATION_CARE_TYPE = "B"
     _TEST_MEDICATION_FREQUENCY = 3
@@ -163,6 +164,8 @@ class MedicationTestMixin(GenericTestMixin):
         extension_medication_frequency = fhir_obj.extension[2].valueTiming
         self.assertTrue(isinstance(extension_medication_frequency, Timing))
         self.assertEqual(self._TEST_MEDICATION_FREQUENCY, extension_medication_frequency.repeat.period)
+        self.assertEqual(int(re.sub("[^0-9]", "", self._TEST_MEDICATION_PACKAGE)), fhir_obj.amount.numerator.value)
+        self.assertEqual(self._TEST_MEDICATION_PACKAGE, fhir_obj.form.text)
 
         extension_usage_context = fhir_obj.extension[3].extension
         for ext in extension_usage_context:

--- a/api_fhir_r4/tests/test/test_medication.json
+++ b/api_fhir_r4/tests/test/test_medication.json
@@ -140,7 +140,7 @@
    },
    "status":"active",
    "form":{
-      "text":"1000 TABLETS"
+      "text":"1000TABLETS"
    },
    "amount":{
       "numerator":{


### PR DESCRIPTION
## Bug Description

When retrieving a medication, its package is represented as a text in the database. It was assumed that it would contain an amount and an unit. The first would be an integer literal, and the second a text, both would be separated by a space.

When working with the demo database, it appeared that several medications didn't have a package complying with that format: the unit is sometimes not separated from the integer by the space (e.g. `10000TABLETS`, `10ml`, `200T`), or there is only a text (e.g. `EACH`).

The API returns then an error (e.g. `invalid literal for int() with base 10: '200T'`).

## Behavior expected

* it doesn't fail and extract the correct amount
* when there isn't any literal I'm assuming there is one something (as there is one record)

## How to reproduce?

Add textual package such as `100l`, `200packets`, `each`, 

## Fix description

This change fixes this bug as it follows:

* the integer literal is extracted (thanks to a regexp),
* if there isn't one found, the amount 1 is returned.

There are still some commented code to remove, I'll clean up when I got your feedback.

## Questions

* As it is my first PR here, please tell me if I'm doing something wrong (report format, quality rules to follow, and so on). :bow: 
* What should we assume when the package is only textual? Is my hypothesis the right one?