### PR TITLE
Fix pagination bug when listing practitioner

### DIFF
--- a/api_fhir_r4/multiserializer/mixins.py
+++ b/api_fhir_r4/multiserializer/mixins.py
@@ -230,7 +230,7 @@ class _JoinedQuerysets:
             if start:
                 start_qs, qs_idx = self.__get_queryset_for_index(start)
                 intersection[0] = self.querysets.index(start_qs) + 1
-                start_qs = start_qs.all()[:qs_idx]
+                start_qs = start_qs.all()[qs_idx:]
             if end:
                 end_qs, qs_idx = self.__get_queryset_for_index(end)
                 intersection[1] = self.querysets.index(end_qs)
@@ -263,7 +263,9 @@ class _JoinedQuerysets:
             if k < next_queryset_last_index:
                 index_in_queryset = k - (next_queryset_last_index - qs_len)
                 return qs, index_in_queryset
-        raise IndexError
+            if k == next_queryset_last_index:
+                return qs, 0
+        raise IndexError(f"for index {k}")
 
     def count(self):
         return sum([qs.count() for qs in self.querysets])


### PR DESCRIPTION
## Context

The practitioners are a joined set of claim admins and enrollment officers. When listing them, the result is paginated. To do so, they are merged and iterated over.

However, with the demo data, we obtained duplicates and an IndexError in the last page.

## Expected behavior

Iterate over all the pages when listing practitioners with the demo data

## Possible explanation

The duplicates are due to a wrong slice of the sets: it slices until the last index that has been listed in the previous page rather than from.

The IndexError is due to the fact that the last index of the last step will be always out of the bounds used to return the right set, i.e. here the last one.

## Additional comments

This does not yet include tests to reproduce the bug.