### PR TITLE
Fix uncomplete Feedback creation (Claim side)

### DIFF
--- a/api_fhir_r4/serializers/communicationSerializer.py
+++ b/api_fhir_r4/serializers/communicationSerializer.py
@@ -20,4 +20,9 @@ class CommunicationSerializer(BaseFHIRSerializer):
         from core import datetime
         copied_data['feedback_date'] = datetime.datetime.now()
         obj = Feedback.objects.create(**copied_data)
+        imis_claim = Claim.objects.get(id=claim)
+        imis_claim.feedback_status = Claim.FEEDBACK_DELIVERED
+        imis_claim.feedback_available = True
+        imis_claim.feedback = obj
+        imis_claim.save()
         return obj


### PR DESCRIPTION
When creating a Feedback with the FHIR API, only the Feedback object is created. However, on the Claim side, there are a few fields referencing the feedback, its availability, and its status of the feedback claim (that seemed to be SELECTED (i.e. int value `4`)). The present change improves the test to check that this side is also correctly and adequately set, and the correct update of the claim is also made.

I'm not sure to what to do with FeedbackPrompt. So please tell me if there is anything to do on that side too. Thanks