### PR TITLE
OP-1556 bump aiohttp version for security & compat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'djangorestframework',
         'fhir.resources==6.2.0b3',
         'pydantic==1.10.12',
-        'aiohttp==3.8.1',
+        'aiohttp~=3.8.5',
         'asynctest==0.13.0',
         'openimis-be-core',
         'openimis-be-insuree',


### PR DESCRIPTION
This is a security update and prevents the build to work in other modules.
Please check the dependabot on develop that does the same