### PR TITLE
OP-2521/fix insuree identifier not working due to boolean condition

### DIFF
--- a/api_fhir_r4/model_retrievers.py
+++ b/api_fhir_r4/model_retrievers.py
@@ -91,8 +91,11 @@ class CHFIdentifierModelRetriever(CodeIdentifierModelRetriever):
     @classmethod
     def identifier_validator(cls, identifier_value):
         # From model specification
-        return isinstance(identifier_value, str) and validate_insuree_number(identifier_value)
-
+        # Fix: Modified condition to check if validate_insuree_number returns an empty array
+        # Original condition incorrectly evaluated validate_insuree_number as False when it returned an empty array []
+        # New condition explicitly checks for an empty array using len(validate_insuree_number(identifier_value)) == 0
+        # This ensures that a valid insuree number (returning empty array) is correctly evaluated as True
+        return isinstance(identifier_value, str) and len(validate_insuree_number(identifier_value)) == 0
 
 class GroupIdentifierModelRetriever(CHFIdentifierModelRetriever):
     identifier_field = 'head_insuree_id__chf_id'


### PR DESCRIPTION
This pull request addresses an issue in the validation logic for the identifier_value check. The original condition isinstance(identifier_value, str) and validate_insuree_number(identifier_value) incorrectly evaluated to False when validate_insuree_number returned an empty array [], despite an empty array indicating a valid insuree number.


output:
`{
    "resourceType": "Patient",
    "id": "070707070",
    "extension": [
        {
            "url": "https://openimis.github.io/openimis_fhir_r4_ig/StructureDefinition/patient-is-head",
            "valueBoolean": true
        },
        {
            "url": "https://openimis.github.io/openimis_fhir_r4_ig/StructureDefinition/patient-card-issued",
            "valueBoolean": false
        },
        {
            "url": "https://openimis.github.io/openimis_fhir_r4_ig/StructureDefinition/patient-group-reference",
            "valueReference": {
                "reference": "Group/070707070",
                "type": "Group",
                "identifier": {
                    "type": {
                        "coding": [
                            {
                                "system": "https://openimis.github.io/openimis_fhir_r4_ig/CodeSystem/openimis-identifiers",
                                "code": "Code"
                            }
                        ]
                    },
                    "value": "070707070"
                }
            }
        }
    ],
    "identifier": [
        {
            "type": {
                "coding": [
                    {
                        "system": "https://openimis.github.io/openimis_fhir_r4_ig/CodeSystem/openimis-identifiers",
                        "code": "UUID"
                    }
                ]
            },
            "value": "0539afeb-21a1-4b3f-9478-23e6f41b0024"
        },
        {
            "type": {
                "coding": [
                    {
                        "system": "https://openimis.github.io/openimis_fhir_r4_ig/CodeSystem/openimis-identifiers",
                        "code": "Code"
                    }
                ]
            },
            "value": "070707070"
        }
    ],
    "name": [
        {
            "use": "usual",
            "family": "Macintyre",
            "given": [
                "Joseph"
            ]
        }
    ],
    "gender": "male",
    "birthDate": "1950-07-12",
    "address": [
        {
            "extension": [
                {
                    "url": "https://openimis.github.io/openimis_fhir_r4_ig/StructureDefinition/address-municipality",
                    "valueString": "Achi"
                },
                {
                    "url": "https://openimis.github.io/openimis_fhir_r4_ig/StructureDefinition/address-location-reference",
                    "valueReference": {
                        "reference": "Location/R1D1M1V1",
                        "type": "Location",
                        "identifier": {
                            "type": {
                                "coding": [
                                    {
                                        "system": "https://openimis.github.io/openimis_fhir_r4_ig/CodeSystem/openimis-identifiers",
                                        "code": "Code"
                                    }
                                ]
                            },
                            "value": "R1D1M1V1"
                        }
                    }
                }
            ],
            "use": "home",
            "type": "physical",
            "text": "Ranchou road 21",
            "city": "Rachla",
            "district": "Rapta",
            "state": "Ultha"
        }
    ],
    "maritalStatus": {
        "coding": [
            {
                "system": "http://hl7.org/fhir/valueset-marital-status.html",
                "code": "M",
                "display": "Married"
            }
        ]
    },
    "photo": [
        {
            "contentType": "jpg",
            "url": "http://localhost/photo/Images/Updated//070707070_E00001_20180327_0.0_0.0.jpg",
            "title": "070707070_E00001_20180327_0.0_0.0.jpg",
            "creation": "2018-03-27"
        }
    ]
}`