### PR TITLE
Fix fhir converter

### DIFF
--- a/api_fhir_r4/converters/activityDefinitionConverter.py
+++ b/api_fhir_r4/converters/activityDefinitionConverter.py
@@ -318,7 +318,10 @@ class ActivityDefinitionConverter(BaseFHIRConverter, ReferenceConverterMixin):
             imp_coding = cls.build_fhir_venue_coding(Service.CARE_TYPE_IN_PATIENT)
             codeable_concept.coding.append(imp_coding)
 
-        codeable_concept.text = " or ".join([coding.display for coding in codeable_concept.coding])
+        if codeable_concept.coding:
+            codeable_concept.text = " or ".join([coding.display for coding in codeable_concept.coding])
+        else:
+            codeable_concept.text = "AMB"
 
         return codeable_concept
 
@@ -356,7 +359,10 @@ class ActivityDefinitionConverter(BaseFHIRConverter, ReferenceConverterMixin):
             child_coding = cls.build_fhir_patient_category_coding("child")
             codeable_concept.coding.append(child_coding)
 
-        codeable_concept.text = " or ".join([coding.display for coding in codeable_concept.coding])
+        if codeable_concept.coding:
+            codeable_concept.text = " or ".join([coding.display for coding in codeable_concept.coding])
+        else:
+            codeable_concept.text = "Adult"
 
         return codeable_concept
 
@@ -374,10 +380,18 @@ class ActivityDefinitionConverter(BaseFHIRConverter, ReferenceConverterMixin):
 
     @classmethod
     def build_fhir_workflow_coding(cls, workflow):
+        if workflow in ["V", "H"]:
+            workflow="O"
+        if workflow == "s":
+            workflow = "S"
+        if workflow == "c":
+            workflow = "C"
         return cls.build_fhir_mapped_coding(WorkflowMapping.fhir_workflow_coding[workflow])
 
     @classmethod
     def build_fhir_topic_coding(cls, topic):
+        if topic and topic == "c":
+            topic = "C"
         return cls.build_fhir_mapped_coding(ServiceTypeMapping.fhir_service_type_coding[topic])
 
     @classmethod

--- a/api_fhir_r4/paginations.py
+++ b/api_fhir_r4/paginations.py
@@ -53,7 +53,7 @@ class FhirBundleResultsSetPagination(PageNumberPagination):
             try:
                 bundle_entry = BundleEntry(**entry)
             except:
-                bundle.entry.append(bundle_entry)
+                bundle.entry.append(entry)
             bundle.entry.append(bundle_entry)
 
     def build_full_url_for_resource(self, fhir_object):

--- a/api_fhir_r4/paginations.py
+++ b/api_fhir_r4/paginations.py
@@ -50,7 +50,10 @@ class FhirBundleResultsSetPagination(PageNumberPagination):
             entry = {}
             entry['fullUrl'] = self.build_full_url_for_resource(obj)
             entry['resource'] = obj
-            bundle_entry = BundleEntry(**entry)
+            try:
+                bundle_entry = BundleEntry(**entry)
+            except:
+                bundle.entry.append(bundle_entry)
             bundle.entry.append(bundle_entry)
 
     def build_full_url_for_resource(self, fhir_object):

--- a/api_fhir_r4/serializers/__init__.py
+++ b/api_fhir_r4/serializers/__init__.py
@@ -86,7 +86,7 @@ class BaseFHIRSerializer(serializers.Serializer):
 
     def _print_debug_log(self, e):
         import traceback
-        debug_log = "FHIR Mapping for Serializer {self} has failed with exception {e}. Traceback: \n" \
+        debug_log = f"FHIR Mapping for Serializer {self} has failed with exception {e}. Traceback: \n" \
                     + str(traceback.format_stack())
         logger.debug(debug_log)
 


### PR DESCRIPTION
Hello @dragos-dobre we found some errors where retrieving ActivityDefinition trougth FHIR:
{"resourceType": "OperationOutcome", "issue": ["severity": "error" "code": "exception", "details" :("text": "H is missing"}}]}

we also had many issues in Cameroon implementation and this are the fixes we have made.