### PR TITLE
OP-3107: Fix ClaimAttachment base64 stringification bug

### DIFF
--- a/api_fhir_r4/converters/claimConverter.py
+++ b/api_fhir_r4/converters/claimConverter.py
@@ -676,7 +676,7 @@ class ClaimConverter(BaseFHIRConverter, ReferenceConverterMixin):
         attachment_data = {
             "title": valueAttachment.title,
             "filename": valueAttachment.title,
-            "document": valueAttachment.data,
+            "document": valueAttachment.data.decode("utf-8") if isinstance(valueAttachment.data, bytes) else valueAttachment.data,
             "mime": valueAttachment.contentType,
             "date": TimeUtils.str_to_date(valueAttachment.creation),
         }


### PR DESCRIPTION
#Thank you for your contribution to openIMIS!
#Please complete the sections below. Anything in comments is guidance and can be deleted.

# Description

This PR resolves a critical data corruption issue that occurred when submitting FHIR Claim payloads containing attachments (e.g., PDF bills).

When a base64 attachment was sent via FHIR, the underlying parsing library converted the valueAttachment.data payload into a Python bytes object (e.g., b'JVBERi0xLjcK...'). Because this bytes object was passed directly to the Django ORM to be saved in a text field, Python automatically invoked str() on it, which saved the literal representation of the bytes object (including the b prefix and single quotes) into the database, irreversibly corrupting the base64 string.


Fixes Implemented
Updated claimConverter.py -> build_attachment_from_value() to explicitly check if valueAttachment.data is a bytes instance.
If it is, we now explicitly call .decode("utf-8") on the binary data before assigning it to the document dictionary field.
This ensures the Django ORM saves the raw, pure base64 string directly into the database without the Python b'...' artifacts.

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
