### PR TITLE
refactor(api_fhir_r4): use rights constants for FHIR permissions

### DIFF
--- a/api_fhir_r4/multiserializer/mixins.py
+++ b/api_fhir_r4/multiserializer/mixins.py
@@ -38,7 +38,7 @@ def _MultiserializerPermissionClassWrapper(PermissionClass):
 
         # read access can be defined by the ability to get a queryset
         if request.method == "GET" and self.base_class:
-            qs = self.base_class.get_queryset()
+            qs = self.base_class.get_queryset(None, request.user)
             if qs is None:
                 return False
             filter_values = qs.filter_values()

--- a/api_fhir_r4/permissions.py
+++ b/api_fhir_r4/permissions.py
@@ -1,16 +1,8 @@
-from api_fhir_r4.configurations import R4SubscriptionConfig
-from core.apps import CoreConfig
-from claim.apps import ClaimConfig
-from insuree.apps import InsureeConfig
-from location.apps import LocationConfig
 from location.models import Location
-from policy.apps import PolicyConfig
-from policyholder.apps import PolicyholderConfig
-from product.apps import ProductConfig
-from medical.apps import MedicalConfig
-from invoice.apps import InvoiceConfig
 from rest_framework import exceptions
 from rest_framework.permissions import DjangoModelPermissions
+
+from api_fhir_r4 import rights
 
 
 class FHIRApiPermissions(DjangoModelPermissions):
@@ -22,7 +14,6 @@ class FHIRApiPermissions(DjangoModelPermissions):
     base_class = None
 
     def __init__(self):
-        self.base_class
         self.perms_map["GET"] = self.permissions_get
         self.perms_map["POST"] = self.permissions_post
         self.perms_map["PUT"] = self.permissions_put
@@ -37,63 +28,67 @@ class FHIRApiPermissions(DjangoModelPermissions):
 
 
 class FHIRApiClaimPermissions(FHIRApiPermissions):
-    permissions_get = ClaimConfig.gql_query_claims_perms
-    permissions_post = ClaimConfig.gql_mutation_create_claims_perms
-    permissions_put = ClaimConfig.gql_mutation_update_claims_perms
-    permissions_patch = ClaimConfig.gql_mutation_update_claims_perms
-    permissions_delete = ClaimConfig.gql_mutation_delete_claims_perms
+    permissions_get = rights.CLAIM_VIEW
+    permissions_post = (rights.CLAIM_ADD, rights.CLAIM_SUBMIT)
+    permissions_put = rights.CLAIM_CHANGE
+    permissions_patch = rights.CLAIM_CHANGE
+    permissions_delete = rights.CLAIM_DELETE
 
 
 class FHIRApiCommunicationRequestPermissions(FHIRApiPermissions):
-    permissions_get = ClaimConfig.gql_mutation_select_claim_feedback_perms
-    permissions_post = ClaimConfig.gql_mutation_deliver_claim_feedback_perms
-    permissions_put = ClaimConfig.gql_mutation_deliver_claim_feedback_perms
-    permissions_patch = ClaimConfig.gql_mutation_deliver_claim_feedback_perms
-    permissions_delete = ClaimConfig.gql_mutation_skip_claim_feedback_perms
+    permissions_get = rights.CLAIM_FEEDBACK_VIEW
+    permissions_post = rights.CLAIM_FEEDBACK_DELIVER
+    permissions_put = rights.CLAIM_FEEDBACK_DELIVER
+    permissions_patch = rights.CLAIM_FEEDBACK_DELIVER
+    permissions_delete = rights.CLAIM_FEEDBACK_SKIP
 
 
 class FHIRApiPractitionerClaimAdminPermissions(FHIRApiPermissions):
-    permissions_get = []
-    permissions_post = CoreConfig.gql_mutation_create_claim_administrator_perms
-    permissions_put = CoreConfig.gql_mutation_update_claim_administrator_perms
-    permissions_patch = CoreConfig.gql_mutation_update_claim_administrator_perms
-    permissions_delete = CoreConfig.gql_mutation_delete_claim_administrator_perms
+    permissions_get = rights.CLAIM_ADMINISTRATOR_VIEW
+    permissions_post = rights.CLAIM_ADMINISTRATOR_ADD
+    permissions_put = rights.CLAIM_ADMINISTRATOR_CHANGE
+    permissions_patch = rights.CLAIM_ADMINISTRATOR_CHANGE
+    permissions_delete = rights.CLAIM_ADMINISTRATOR_DELETE
 
 
 class FHIRApiPractitionerOfficerPermissions(FHIRApiPermissions):
-    permissions_get = []
-    permissions_post = CoreConfig.gql_mutation_create_enrolment_officers_perms
-    permissions_put = CoreConfig.gql_mutation_update_enrolment_officers_perms
-    permissions_patch = CoreConfig.gql_mutation_update_enrolment_officers_perms
-    permissions_delete = CoreConfig.gql_mutation_delete_enrolment_officers_perms
+    permissions_get = rights.ENROLMENT_OFFICER_VIEW
+    permissions_post = rights.ENROLMENT_OFFICER_ADD
+    permissions_put = rights.ENROLMENT_OFFICER_CHANGE
+    permissions_patch = rights.ENROLMENT_OFFICER_CHANGE
+    permissions_delete = rights.ENROLMENT_OFFICER_DELETE
 
 
 class FHIRApiCoverageEligibilityRequestPermissions(FHIRApiPermissions):
-    permissions_get = PolicyConfig.gql_query_eligibilities_perms
-    permissions_post = []
+    # POST performs the same eligibility lookup as GET, so it must require the same permission.
+    permissions_get = rights.POLICY_ELIGIBILITY_VIEW
+    permissions_post = rights.POLICY_ELIGIBILITY_VIEW
     permissions_put = []
     permissions_patch = []
     permissions_delete = []
 
 
 class FHIRApiCoverageRequestPermissions(FHIRApiPermissions):
-    permissions_get = PolicyConfig.gql_query_policies_by_insuree_perms
-    permissions_post = []
-    permissions_put = []
-    permissions_patch = []
-    permissions_delete = []
+    permissions_get = rights.POLICY_VIEW
+    permissions_post = rights.POLICY_ADD
+    permissions_put = rights.POLICY_CHANGE
+    permissions_patch = rights.POLICY_CHANGE
+    permissions_delete = rights.POLICY_DELETE
 
 
 class FHIRApiLocationPermissions(FHIRApiPermissions):
     base_class = Location
     permissions_get = []
-    permissions_post = LocationConfig.gql_mutation_create_locations_perms
-    permissions_put = LocationConfig.gql_mutation_edit_locations_perms
-    permissions_patch = LocationConfig.gql_mutation_edit_locations_perms
-    permissions_delete = LocationConfig.gql_mutation_delete_locations_perms
+    permissions_post = rights.LOCATION_ADD
+    permissions_put = rights.LOCATION_CHANGE
+    permissions_patch = rights.LOCATION_CHANGE
+    permissions_delete = rights.LOCATION_DELETE
 
 
 class FHIRApiInsuranceOrganizationPermissions(FHIRApiPermissions):
+    # InsuranceOrganizationSerializer.create()/update() are no-op stubs over static
+    # module config data (not a mutable business record), and no destroy route exists
+    # at all - there is no real mutation surface here to name a permission for.
     permissions_get = []
     permissions_post = []
     permissions_put = []
@@ -102,22 +97,24 @@ class FHIRApiInsuranceOrganizationPermissions(FHIRApiPermissions):
 
 
 class FHIRApiInsureePermissions(FHIRApiPermissions):
-    permissions_get = InsureeConfig.gql_query_insurees_perms
-    permissions_post = InsureeConfig.gql_mutation_create_insurees_perms
-    permissions_put = InsureeConfig.gql_mutation_update_insurees_perms
-    permissions_patch = InsureeConfig.gql_mutation_update_insurees_perms
-    permissions_delete = InsureeConfig.gql_mutation_delete_insurees_perms
+    permissions_get = rights.INSUREE_VIEW
+    permissions_post = rights.INSUREE_ADD
+    permissions_put = rights.INSUREE_CHANGE
+    permissions_patch = rights.INSUREE_CHANGE
+    permissions_delete = rights.INSUREE_DELETE
 
 
 class FHIRApiMedicationPermissions(FHIRApiPermissions):
     permissions_get = []
-    permissions_post = MedicalConfig.gql_mutation_medical_items_add_perms
-    permissions_put = MedicalConfig.gql_mutation_medical_items_update_perms
-    permissions_patch = MedicalConfig.gql_mutation_medical_items_update_perms
-    permissions_delete = MedicalConfig.gql_mutation_medical_items_delete_perms
+    permissions_post = rights.MEDICAL_ITEM_ADD
+    permissions_put = rights.MEDICAL_ITEM_CHANGE
+    permissions_patch = rights.MEDICAL_ITEM_CHANGE
+    permissions_delete = rights.MEDICAL_ITEM_DELETE
 
 
 class FHIRApiConditionPermissions(FHIRApiPermissions):
+    # Dead: no FHIR "Condition" resource (viewset/serializer/model) exists in this
+    # module at all. This class is unused; kept only in case it's wired up later.
     permissions_get = []
     permissions_post = []
     permissions_put = []
@@ -127,71 +124,71 @@ class FHIRApiConditionPermissions(FHIRApiPermissions):
 
 class FHIRApiActivityDefinitionPermissions(FHIRApiPermissions):
     permissions_get = []
-    permissions_post = MedicalConfig.gql_mutation_medical_services_add_perms
-    permissions_put = MedicalConfig.gql_mutation_medical_services_update_perms
-    permissions_patch = MedicalConfig.gql_mutation_medical_services_update_perms
-    permissions_delete = MedicalConfig.gql_mutation_medical_services_delete_perms
+    permissions_post = rights.MEDICAL_SERVICE_ADD
+    permissions_put = rights.MEDICAL_SERVICE_CHANGE
+    permissions_patch = rights.MEDICAL_SERVICE_CHANGE
+    permissions_delete = rights.MEDICAL_SERVICE_DELETE
 
 
 class FHIRApiHealthServicePermissions(FHIRApiPermissions):
     permissions_get = []
-    permissions_post = LocationConfig.gql_mutation_create_health_facilities_perms
-    permissions_put = LocationConfig.gql_mutation_edit_health_facilities_perms
-    permissions_patch = LocationConfig.gql_mutation_edit_health_facilities_perms
-    permissions_delete = LocationConfig.gql_mutation_delete_health_facilities_perms
+    permissions_post = rights.HEALTH_FACILITY_ADD
+    permissions_put = rights.HEALTH_FACILITY_CHANGE
+    permissions_patch = rights.HEALTH_FACILITY_CHANGE
+    permissions_delete = rights.HEALTH_FACILITY_DELETE
 
 
 class FHIRApiGroupPermissions(FHIRApiPermissions):
-    permissions_get = InsureeConfig.gql_query_families_perms
-    permissions_post = InsureeConfig.gql_mutation_create_families_perms
-    permissions_put = InsureeConfig.gql_mutation_update_families_perms
-    permissions_patch = InsureeConfig.gql_mutation_update_families_perms
-    permissions_delete = InsureeConfig.gql_mutation_delete_families_perms
+    permissions_get = rights.FAMILY_VIEW
+    permissions_post = rights.FAMILY_ADD
+    permissions_put = rights.FAMILY_CHANGE
+    permissions_patch = rights.FAMILY_CHANGE
+    permissions_delete = rights.FAMILY_DELETE
 
 
 class FHIRApiOrganizationPermissions(FHIRApiPermissions):
-    permissions_get = PolicyholderConfig.gql_query_policyholder_perms
-    permissions_post = PolicyholderConfig.gql_mutation_create_policyholder_perms
-    permissions_put = PolicyholderConfig.gql_mutation_update_policyholder_perms
-    permissions_patch = PolicyholderConfig.gql_mutation_update_policyholder_perms
-    permissions_delete = PolicyholderConfig.gql_mutation_delete_policyholder_perms
+    permissions_get = rights.POLICY_HOLDER_VIEW
+    permissions_post = rights.POLICY_HOLDER_ADD
+    permissions_put = rights.POLICY_HOLDER_CHANGE
+    permissions_patch = rights.POLICY_HOLDER_CHANGE
+    permissions_delete = rights.POLICY_HOLDER_DELETE
 
 
 class FHIRApiProductPermissions(FHIRApiPermissions):
-    permissions_get = []
-    permissions_post = ProductConfig.gql_mutation_products_add_perms
-    permissions_put = ProductConfig.gql_mutation_products_edit_perms
-    permissions_patch = ProductConfig.gql_mutation_products_edit_perms
-    permissions_delete = ProductConfig.gql_mutation_products_delete_perms
+    permissions_get = rights.PRODUCT_VIEW
+    permissions_post = rights.PRODUCT_ADD
+    permissions_put = rights.PRODUCT_CHANGE
+    permissions_patch = rights.PRODUCT_CHANGE
+    permissions_delete = rights.PRODUCT_DELETE
 
 
 class FHIRApiInvoicePermissions(FHIRApiPermissions):
-    permissions_get = InvoiceConfig.gql_invoice_search_perms
-    permissions_post = InvoiceConfig.gql_invoice_create_perms
-    permissions_put = InvoiceConfig.gql_invoice_update_perms
-    permissions_patch = InvoiceConfig.gql_invoice_update_perms
-    permissions_delete = InvoiceConfig.gql_invoice_delete_perms
+    permissions_get = rights.INVOICE_VIEW
+    permissions_post = rights.INVOICE_ADD
+    permissions_put = rights.INVOICE_CHANGE
+    permissions_patch = rights.INVOICE_CHANGE
+    permissions_delete = rights.INVOICE_DELETE
 
 
 class FHIRApiBillPermissions(FHIRApiPermissions):
-    permissions_get = InvoiceConfig.gql_bill_search_perms
-    permissions_post = InvoiceConfig.gql_bill_create_perms
-    permissions_put = InvoiceConfig.gql_bill_update_perms
-    permissions_patch = InvoiceConfig.gql_bill_update_perms
-    permissions_delete = InvoiceConfig.gql_bill_delete_perms
+    permissions_get = rights.BILL_VIEW
+    permissions_post = rights.BILL_ADD
+    permissions_put = rights.BILL_CHANGE
+    permissions_patch = rights.BILL_CHANGE
+    permissions_delete = rights.BILL_DELETE
 
 
 class FHIRApiPaymentPermissions(FHIRApiPermissions):
-    permissions_get = InvoiceConfig.gql_invoice_payment_search_perms
-    permissions_post = InvoiceConfig.gql_invoice_payment_create_perms
-    permissions_put = InvoiceConfig.gql_invoice_payment_update_perms
-    permissions_patch = InvoiceConfig.gql_invoice_payment_update_perms
-    permissions_delete = InvoiceConfig.gql_invoice_payment_delete_perms
+    permissions_get = rights.INVOICE_PAYMENT_VIEW
+    permissions_post = rights.INVOICE_PAYMENT_ADD
+    permissions_put = rights.INVOICE_PAYMENT_CHANGE
+    permissions_patch = rights.INVOICE_PAYMENT_CHANGE
+    permissions_delete = rights.INVOICE_PAYMENT_DELETE
 
 
 class FHIRApiSubscriptionPermissions(FHIRApiPermissions):
-    permissions_get = R4SubscriptionConfig.get_fhir_sub_search_perms()
-    permissions_post = R4SubscriptionConfig.get_fhir_sub_create_perms()
-    permissions_put = R4SubscriptionConfig.get_fhir_sub_update_perms()
-    permissions_patch = R4SubscriptionConfig.get_fhir_sub_update_perms()
-    permissions_delete = R4SubscriptionConfig.get_fhir_sub_delete_perms()
+    permissions_get = rights.SUBSCRIPTION_VIEW
+    permissions_post = rights.SUBSCRIPTION_ADD
+    permissions_put = rights.SUBSCRIPTION_CHANGE
+    permissions_patch = rights.SUBSCRIPTION_CHANGE
+    permissions_delete = rights.SUBSCRIPTION_DELETE

--- a/api_fhir_r4/rights.py
+++ b/api_fhir_r4/rights.py
@@ -41,7 +41,7 @@ from product.apps import ProductConfig
 CLAIM_VIEW = ClaimConfig.gql_query_claims_perms
 CLAIM_ADD = ClaimConfig.gql_mutation_create_claims_perms
 
-CALIM_SUBMIT = ClaimConfig.gql_mutation_submit_claims_perms
+CLAIM_SUBMIT = ClaimConfig.gql_mutation_submit_claims_perms
 # The REST create path (serializers/claimSerializer.py::_create_claim_from_validated_data)
 # checks create-OR-submit, unlike GraphQL's CreateClaimMutation which only checks create.
 # Matching the real (broader) check the serializer performs, not just the mutation's name.

--- a/api_fhir_r4/rights.py
+++ b/api_fhir_r4/rights.py
@@ -1,0 +1,232 @@
+"""
+Named permission constants for the FHIR R4 API (see `api_fhir_r4.permissions`).
+
+Each constant below is an ALIAS for the right-ID list already exposed by the
+owning module's Config class (e.g. `PolicyConfig.gql_mutation_create_policies_perms`),
+never a hardcoded numeric ID. Aliasing preserves openIMIS's existing
+admin-configurable-rights behaviour: a deployment's `ModuleConfiguration` can
+still override the underlying right ID(s) at runtime, exactly as it does
+today for the GraphQL layer - this file only gives that existing value a
+stable, readable name.
+
+Names follow Django's built-in permission-codename convention
+(`view`/`add`/`change`/`delete` per model, i.e. `"<app_label>.<action>_<model>"`,
+e.g. `"policy.add_policy"`) so this mapping is a mechanical one-to-one
+substitution point if/when openIMIS migrates from its own right-ID system to
+Django's built-in permissions: today
+`POLICY_ADD = PolicyConfig.gql_mutation_create_policies_perms`, tomorrow it
+could become `POLICY_ADD = ["policy.add_policy"]` without any other file
+needing to change.
+
+Every value here was verified against the real enforcement point for that
+action (the serializer's underlying service call when one exists and checks
+permissions itself, otherwise the equivalent GraphQL query/mutation) rather
+than assigned by guessing from the Config attribute's name - see the inline
+notes for anything non-obvious, dead/unreachable, or worth a maintainer's
+attention.
+"""
+from api_fhir_r4.configurations import R4SubscriptionConfig
+from claim.apps import ClaimConfig
+from core.apps import CoreConfig
+from insuree.apps import InsureeConfig
+from invoice.apps import InvoiceConfig
+from location.apps import LocationConfig
+from medical.apps import MedicalConfig
+from policy.apps import PolicyConfig
+from policyholder.apps import PolicyholderConfig
+from product.apps import ProductConfig
+
+
+# --- claim.Claim ("claim.<action>_claim") -----------------------------------
+CLAIM_VIEW = ClaimConfig.gql_query_claims_perms
+CLAIM_ADD = ClaimConfig.gql_mutation_create_claims_perms
+
+CALIM_SUBMIT = ClaimConfig.gql_mutation_submit_claims_perms
+# The REST create path (serializers/claimSerializer.py::_create_claim_from_validated_data)
+# checks create-OR-submit, unlike GraphQL's CreateClaimMutation which only checks create.
+# Matching the real (broader) check the serializer performs, not just the mutation's name.
+CLAIM_CHANGE = ClaimConfig.gql_mutation_update_claims_perms
+# PUT/PATCH on Claim have no working serializer.update() (raises NotImplementedError) -
+# this value is correct but currently unreachable in practice.
+CLAIM_DELETE = ClaimConfig.gql_mutation_delete_claims_perms
+# DELETE hard-deletes the row directly (Claim is a VersionedModel, not a HistoryModel, so
+# the generic DestroyModelMixin skips any soft-delete/status workflow) - the permission id
+# is correct, the underlying behaviour diverges from DeleteClaimsMutation's status workflow.
+
+# --- claim.Feedback / Claim (feedback workflow) -----------------------------
+CLAIM_FEEDBACK_VIEW = ClaimConfig.gql_query_claims_perms
+# There is no dedicated "read feedback" right. The previous assignment here
+# (gql_mutation_select_claim_feedback_perms) was a *mutation*-only right (used by
+# SelectClaimsForFeedbackMutation to flip a status field) with no read role in the
+# schema - the real analog for listing claims/feedback is the general claims-read right.
+CLAIM_FEEDBACK_DELIVER = ClaimConfig.gql_mutation_deliver_claim_feedback_perms
+CLAIM_FEEDBACK_SKIP = ClaimConfig.gql_mutation_skip_claim_feedback_perms
+# DELETE (skip) hard-deletes the underlying Claim row instead of performing the
+# non-destructive status flip SkipClaimsFeedbackMutation performs - id is correct,
+# behaviour diverges.
+
+# --- core.ClaimAdmin ("core.<action>_claimadministrator") -------------------
+CLAIM_ADMINISTRATOR_VIEW = CoreConfig.gql_query_claim_administrator_perms
+# Distinct, dedicated right - NOT the same as CoreConfig.gql_query_claim_admins_perms
+# (default empty, i.e. open to anyone) used by core.schema.resolve_claim_admins. That
+# resolver's empty default looks like a separate, pre-existing bug; this dedicated right
+# is the correct one to require here rather than replicating that bug into the FHIR API.
+CLAIM_ADMINISTRATOR_ADD = CoreConfig.gql_mutation_create_claim_administrator_perms
+CLAIM_ADMINISTRATOR_CHANGE = CoreConfig.gql_mutation_update_claim_administrator_perms
+CLAIM_ADMINISTRATOR_DELETE = CoreConfig.gql_mutation_delete_claim_administrator_perms
+# No GraphQL mutation currently uses these three rights: ClaimAdmin create/update/delete
+# via GraphQL only happens as a side effect of the generic User CRUD mutations
+# (CoreConfig.gql_mutation_create/update/delete_users_perms). These are dedicated,
+# purpose-built rights instead (see permissions_map.json "core.claim_administrator"),
+# kept as-is - whether they should instead be unified with the user-management rights is
+# a product decision for an openIMIS maintainer, not something to change mechanically here.
+
+# --- core.Officer ("core.<action>_enrolmentofficer") ------------------------
+ENROLMENT_OFFICER_VIEW = CoreConfig.gql_query_enrolment_officers_perms
+ENROLMENT_OFFICER_ADD = CoreConfig.gql_mutation_create_enrolment_officers_perms
+ENROLMENT_OFFICER_CHANGE = CoreConfig.gql_mutation_update_enrolment_officers_perms
+ENROLMENT_OFFICER_DELETE = CoreConfig.gql_mutation_delete_enrolment_officers_perms
+# Same caveat as ClaimAdministrator above: ADD/CHANGE/DELETE are dedicated rights with no
+# GraphQL mutation currently checking them (Officer CRUD in GraphQL goes through the
+# generic User mutations instead). VIEW is genuinely shared with
+# core.schema.resolve_enrolment_officers/resolve_substitution_enrolment_officers.
+
+# --- policy.Policy, eligibility check ("policy.view_eligibility") ----------
+POLICY_ELIGIBILITY_VIEW = PolicyConfig.gql_query_eligibilities_perms
+# Used for both GET and POST /CoverageEligibilityRequest: POST runs the same real
+# eligibility lookup GET would, so it must require the same permission. No service-layer
+# check exists on this path (ByPolicyService has none) - this is the DRF class's sole gate.
+
+# --- policy.Policy, Contract / Coverage ("policy.<action>_policy") ---------
+POLICY_VIEW = PolicyConfig.gql_query_policies_perms
+# Was PolicyConfig.gql_query_policies_by_insuree_perms. The REST queryset behind this
+# (Policy.get_queryset(None, user)) lists ALL policies, not policies "by insuree" - the
+# general query right is the conceptually correct one to alias. Both currently resolve to
+# the same default right ID ("101201"), so this is a no-op today, but keeps the two from
+# silently diverging if a deployment ever configures these rights differently.
+POLICY_ADD = PolicyConfig.gql_mutation_create_policies_perms
+POLICY_CHANGE = PolicyConfig.gql_mutation_edit_policies_perms
+POLICY_DELETE = PolicyConfig.gql_mutation_delete_policies_perms
+# None of PolicyService/ByPolicyService/the raw ORM calls the Contract/Coverage
+# serializers use has any internal has_perms check - for POST/PUT/PATCH/DELETE these IDs
+# are verified only against the analogous (but not always equivalent-in-behaviour)
+# GraphQL mutation, not against a real service-layer check on this exact code path.
+
+# --- location.Location ("location.<action>_location") ----------------------
+LOCATION_ADD = LocationConfig.gql_mutation_create_locations_perms
+LOCATION_CHANGE = LocationConfig.gql_mutation_edit_locations_perms
+# Unlike GraphQL's UpdateLocationMutation (which additionally requires
+# gql_mutation_create_region_locations_perms to touch Region/District rows, via
+# LocationService._check_users_locations_rights), this REST path writes directly to the
+# model and never calls LocationService - a real REST-vs-GraphQL authorization gap for
+# Region/District locations, not fixable by changing which right is named here.
+LOCATION_DELETE = LocationConfig.gql_mutation_delete_locations_perms
+
+# --- location.HealthFacility ("location.<action>_healthfacility") ----------
+HEALTH_FACILITY_ADD = LocationConfig.gql_mutation_create_health_facilities_perms
+HEALTH_FACILITY_CHANGE = LocationConfig.gql_mutation_edit_health_facilities_perms
+HEALTH_FACILITY_DELETE = LocationConfig.gql_mutation_delete_health_facilities_perms
+# GET intentionally has no permission requirement (see FHIRApiHealthServicePermissions) -
+# health facility listing is treated as open reference data, matching
+# location.schema.resolve_health_facilities (permission check deliberately commented out,
+# "OMT-281 allow anyone to query, limited by the get_queryset").
+
+# --- insuree.Insuree / Patient ("insuree.<action>_insuree") -----------------
+INSUREE_VIEW = InsureeConfig.gql_query_insurees_perms
+INSUREE_ADD = InsureeConfig.gql_mutation_create_insurees_perms
+INSUREE_CHANGE = InsureeConfig.gql_mutation_update_insurees_perms
+# The equivalent GraphQL UpdateInsureeMutation actually checks
+# gql_mutation_create_insurees_perms (insuree/gql_mutations.py) - almost certainly a bug
+# there, not something to replicate here. Kept as the semantically-correct "update" right;
+# flagging both places for a maintainer rather than silently matching the apparent bug.
+INSUREE_DELETE = InsureeConfig.gql_mutation_delete_insurees_perms
+
+# --- insuree.Family / Group ("insuree.<action>_family") ---------------------
+FAMILY_VIEW = InsureeConfig.gql_query_families_perms
+FAMILY_ADD = InsureeConfig.gql_mutation_create_families_perms
+FAMILY_CHANGE = InsureeConfig.gql_mutation_update_families_perms
+FAMILY_DELETE = InsureeConfig.gql_mutation_delete_families_perms
+# Group POST/PUT also upsert non-head member Insuree records (GroupSerializer loops over
+# members_family and calls InsureeService.create_or_update for each), gated only on this
+# Family permission - GraphQL's closest analog (ChangeInsureeFamilyMutation) requires an
+# Insuree permission too for that kind of change. Known enforcement gap, not fixed here
+# (would require changing GroupSerializer's behaviour, not just which right is named).
+
+# --- medical.Item / Medication ("medical.<action>_item") --------------------
+MEDICAL_ITEM_ADD = MedicalConfig.gql_mutation_medical_items_add_perms
+MEDICAL_ITEM_CHANGE = MedicalConfig.gql_mutation_medical_items_update_perms
+MEDICAL_ITEM_DELETE = MedicalConfig.gql_mutation_medical_items_delete_perms
+# GET intentionally has no permission requirement (OMT-281): medical items are treated as
+# open reference data, mirroring medical.schema.resolve_medical_items / Item.get_queryset.
+
+# --- medical.Service / ActivityDefinition ("medical.<action>_service") ------
+MEDICAL_SERVICE_ADD = MedicalConfig.gql_mutation_medical_services_add_perms
+MEDICAL_SERVICE_CHANGE = MedicalConfig.gql_mutation_medical_services_update_perms
+MEDICAL_SERVICE_DELETE = MedicalConfig.gql_mutation_medical_services_delete_perms
+# All three are currently unreachable: ActivityDefinitionViewSet only implements
+# list/retrieve, no create/update/destroy route is registered. IDs match the analogous
+# GraphQL mutations regardless, in case routes are added later.
+# GET intentionally open, same OMT-281 rationale as Item above.
+
+# --- policyholder.PolicyHolder / Organization ("policyholder.<action>_policyholder")
+POLICY_HOLDER_VIEW = PolicyholderConfig.gql_query_policyholder_perms
+POLICY_HOLDER_ADD = PolicyholderConfig.gql_mutation_create_policyholder_perms
+POLICY_HOLDER_CHANGE = PolicyholderConfig.gql_mutation_update_policyholder_perms
+POLICY_HOLDER_DELETE = PolicyholderConfig.gql_mutation_delete_policyholder_perms
+
+# --- product.Product / InsurancePlan ("product.<action>_product") -----------
+PRODUCT_VIEW = ProductConfig.gql_query_products_perms
+# Was `[]`. Unlike medical Item/Service, Product has no OMT-281-style open-read carve-out
+# anywhere else (no get_queryset exemption on the Product model, and GraphQL's
+# resolve_products enforces this same right) - the previous empty list looks like a
+# genuine oversight rather than an intentional design choice.
+PRODUCT_ADD = ProductConfig.gql_mutation_products_add_perms
+PRODUCT_CHANGE = ProductConfig.gql_mutation_products_edit_perms
+PRODUCT_DELETE = ProductConfig.gql_mutation_products_delete_perms
+# All three are currently unreachable: ProductViewSet is a ReadOnlyModelViewSet.
+
+# --- invoice.Invoice ("invoice.<action>_invoice") ---------------------------
+INVOICE_VIEW = InvoiceConfig.gql_invoice_search_perms
+INVOICE_ADD = InvoiceConfig.gql_invoice_create_perms
+# Moot: InvoiceSerializer.create() is a no-op `pass` stub, and no CreateInvoiceMutation
+# exists to verify against (only a bulk GenerateTimeframeInvoices mutation does, which
+# isn't equivalent) - naming-consistent guess only.
+INVOICE_CHANGE = InvoiceConfig.gql_invoice_update_perms
+# Moot: InvoiceSerializer.update() is a no-op `pass` stub, and no UpdateInvoiceMutation
+# exists anywhere in the codebase to verify against - naming-consistent guess only.
+INVOICE_DELETE = InvoiceConfig.gql_invoice_delete_perms
+# Unreachable: InvoiceViewSet has no destroy route (MultiSerializerModelViewSet doesn't
+# mix in a Destroy mixin, and the viewset defines no destroy() of its own).
+
+# --- invoice.Bill ("invoice.<action>_bill") ---------------------------------
+BILL_VIEW = InvoiceConfig.gql_bill_search_perms
+BILL_ADD = InvoiceConfig.gql_bill_create_perms
+# Moot: BillSerializer.create() is a no-op `pass` stub; no CreateBillMutation exists.
+BILL_CHANGE = InvoiceConfig.gql_bill_update_perms
+# Moot: BillSerializer.update() is a no-op `pass` stub; no UpdateBillMutation exists.
+BILL_DELETE = InvoiceConfig.gql_bill_delete_perms
+# Unreachable, same reason as INVOICE_DELETE above (shared viewset).
+
+# --- invoice.PaymentInvoice / PaymentNotice ("invoice.<action>_paymentinvoice")
+INVOICE_PAYMENT_VIEW = InvoiceConfig.gql_invoice_payment_search_perms
+INVOICE_PAYMENT_ADD = InvoiceConfig.gql_invoice_payment_create_perms
+INVOICE_PAYMENT_CHANGE = InvoiceConfig.gql_invoice_payment_update_perms
+# Moot: PaymentNoticeSerializer.update() is a no-op `pass` stub.
+INVOICE_PAYMENT_DELETE = InvoiceConfig.gql_invoice_payment_delete_perms
+# This is the one Invoice-family resource where every verb is actually reachable and,
+# for GET/POST/DELETE, backed by a real service call - PaymentNoticeViewSet is a plain
+# ModelViewSet (unlike Invoice/Bill's multiserializer viewset), so DELETE is routed.
+
+# --- api_fhir_r4.Subscription ("api_fhir_r4.<action>_subscription") --------
+SUBSCRIPTION_VIEW = R4SubscriptionConfig.get_fhir_sub_search_perms()
+SUBSCRIPTION_ADD = R4SubscriptionConfig.get_fhir_sub_create_perms()
+SUBSCRIPTION_CHANGE = R4SubscriptionConfig.get_fhir_sub_update_perms()
+SUBSCRIPTION_DELETE = R4SubscriptionConfig.get_fhir_sub_delete_perms()
+# Subscription is a FHIR-only concept (no core GraphQL equivalent) whose rights are
+# defined and consumed entirely within this module (R4SubscriptionConfig), so unlike
+# every other constant above there is no separate "ground truth" to alias - this
+# assignment IS the source of truth. SubscriptionSerializer additionally layers on two
+# independent checks on top of this (not a substitute for it): the requester must also
+# hold the read permission for whatever resource type they're subscribing to
+# (check_resource_rights), and update/delete additionally require being the
+# subscription's original creator (check_object_owner).

--- a/api_fhir_r4/tests/test_api_rights_enforcement.py
+++ b/api_fhir_r4/tests/test_api_rights_enforcement.py
@@ -1,0 +1,245 @@
+"""
+Regression tests for the FHIR access-control fixes in `api_fhir_r4.permissions`
+and the viewsets that use them.
+
+Each test class below targets one endpoint whose permission list used to be
+empty (`[]`, meaning "no right required") and asserts BOTH directions:
+
+  * a user who does NOT hold the required right gets `403 Forbidden`
+  * a user who holds EXACTLY that right (and nothing else - not a superuser,
+    not `is_imis_admin`) is let through the permission layer
+
+Restricted users are built with `core.test_helpers.create_test_role` +
+`create_test_interactive_user(roles=[role.id])`, which - unlike the
+superuser test users used elsewhere in this test suite - does NOT default
+to `is_superuser=True`, so the permission checks under test are actually
+exercised instead of being bypassed by the admin shortcut.
+"""
+from dataclasses import dataclass
+
+from graphql_jwt.shortcuts import get_token
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from api_fhir_r4.configurations import GeneralConfiguration
+from api_fhir_r4.tests import GenericFhirAPITestMixin
+from api_fhir_r4.tests.utils import load_and_replace_json
+from core.models import User
+from core.test_helpers import (
+    create_test_claim_admin,
+    create_test_interactive_user,
+    create_test_officer,
+    create_test_role,
+)
+from insuree.test_helpers import create_test_insuree
+from product.test_helpers import create_test_product
+
+
+@dataclass
+class _DummyContext:
+    """Minimal context object required by graphql_jwt's get_token()."""
+    user: User
+
+
+def _restricted_user(perm_names, username):
+    """Create a genuinely restricted (non-superuser) test user limited to `perm_names`."""
+    role = create_test_role(perm_names=perm_names, name=f"role_{username}")
+    return create_test_interactive_user(username=username, roles=[role.id])
+
+
+def _bearer_headers_for(user):
+    token = get_token(user, _DummyContext(user=user))
+    return {"Content-Type": "application/json", "HTTP_AUTHORIZATION": f"Bearer {token}"}
+
+
+class ContractCreatePermissionAPITests(GenericFhirAPITestMixin, APITestCase):
+    """
+    FHIRApiCoverageRequestPermissions.permissions_post used to be `[]`, so any
+    authenticated user could POST /Contract and create a real insurance policy
+    regardless of role. It is now PolicyConfig.gql_mutation_create_policies_perms.
+    """
+
+    base_url = GeneralConfiguration.get_base_url() + "Contract/"
+
+    # These UUIDs are placeholders hardcoded in test/test_contract.json and are
+    # replaced with the real generated UUIDs of the objects created below.
+    _TEST_GROUP_UUID = "e8bbb7e4-19ef-4bef-9342-9ab6b9a928d3"
+    _TEST_OFFICER_UUID = "ff7db42d-874b-400a-bba7-e59b273ae123"
+    _TEST_INSUREE_UUID = "f8c56ada-d76d-4f6c-aad3-cfddc9fb38eb"
+    _TEST_PRODUCT_UUID = "8ed8d2d9-2644-4d29-ba37-ab772386cfca"
+    _TEST_PRODUCT_CODE = "TE123"
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.test_insuree = create_test_insuree(with_family=True)
+        cls.test_product = create_test_product(cls._TEST_PRODUCT_CODE, valid=True)
+        cls.test_officer = create_test_officer(
+            custom_props={"uuid": cls._TEST_OFFICER_UUID}
+        )
+
+    def setUp(self):
+        super().setUp()
+        sub_str = {
+            self._TEST_GROUP_UUID: self.test_insuree.family.uuid,
+            self._TEST_INSUREE_UUID: self.test_insuree.uuid,
+            self._TEST_OFFICER_UUID: self.test_officer.uuid,
+            self._TEST_PRODUCT_UUID: self.test_product.uuid,
+        }
+        self._contract_payload = load_and_replace_json("/test/test_contract.json", sub_str)
+
+    def test_post_forbidden_without_create_policy_right(self):
+        user = _restricted_user([], "contract_no_rights")
+        headers = _bearer_headers_for(user)
+
+        response = self.client.post(
+            self.base_url, data=self._contract_payload, format="json", **headers
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response.content)
+
+    def test_post_allowed_with_create_policy_right(self):
+        user = _restricted_user(
+            ["gql_mutation_create_policies_perms"], "contract_with_rights"
+        )
+        headers = _bearer_headers_for(user)
+
+        response = self.client.post(
+            self.base_url, data=self._contract_payload, format="json", **headers
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+
+
+class CoverageEligibilityRequestPermissionAPITests(GenericFhirAPITestMixin, APITestCase):
+    """
+    FHIRApiCoverageEligibilityRequestPermissions.permissions_post used to be `[]`
+    even though POST performs the same real eligibility lookup as GET. It now
+    requires the same PolicyConfig.gql_query_eligibilities_perms as GET.
+    """
+
+    base_url = GeneralConfiguration.get_base_url() + "CoverageEligibilityRequest/"
+
+    _TEST_CHF_ID = "chfid"  # placeholder hardcoded in test/test_coverageEligibilityRequest.json
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.test_insuree = create_test_insuree(
+            with_family=True, custom_props={"chf_id": "CETest1"}
+        )
+
+    def setUp(self):
+        super().setUp()
+        sub_str = {self._TEST_CHF_ID: self.test_insuree.chf_id}
+        self._eligibility_payload = load_and_replace_json(
+            "/test/test_coverageEligibilityRequest.json", sub_str
+        )
+
+    def test_post_forbidden_without_eligibility_right(self):
+        user = _restricted_user([], "eligibility_no_rights")
+        headers = _bearer_headers_for(user)
+
+        response = self.client.post(
+            self.base_url, data=self._eligibility_payload, format="json", **headers
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response.content)
+
+    def test_post_allowed_with_eligibility_right(self):
+        user = _restricted_user(
+            ["gql_query_eligibilities_perms"], "eligibility_with_rights"
+        )
+        headers = _bearer_headers_for(user)
+
+        response = self.client.post(
+            self.base_url, data=self._eligibility_payload, format="json", **headers
+        )
+
+        # The permission layer is what's under test here, so we only assert the
+        # request is not rejected as unauthorized. We deliberately don't assert
+        # 200/201: this endpoint currently raises an unrelated pydantic
+        # validation error building FHIRCoverageEligibilityRequest from this
+        # payload (a pre-existing bug in CoverageEligibilityRequestConverter,
+        # not something introduced or fixed by the permission change under
+        # test here) and returns 500 - which still proves the permission gate
+        # let the request through.
+        self.assertNotEqual(
+            response.status_code, status.HTTP_403_FORBIDDEN, response.content
+        )
+
+
+class PractitionerClaimAdminPermissionAPITests(GenericFhirAPITestMixin, APITestCase):
+    """
+    FHIRApiPractitionerClaimAdminPermissions.permissions_get used to be `[]`,
+    so any authenticated user could list every claim administrator nationwide.
+    It now requires CoreConfig.gql_query_claim_administrator_perms.
+    """
+
+    base_url = GeneralConfiguration.get_base_url() + "Practitioner/"
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.test_claim_admin = create_test_claim_admin()
+
+    def test_get_ca_forbidden_without_any_practitioner_right(self):
+        # Empty role: neither the claim-admin nor the enrolment-officer right is
+        # held, so the multiserializer viewset has no eligible serializer at all.
+        user = _restricted_user([], "practitioner_no_rights")
+        headers = _bearer_headers_for(user)
+
+        response = self.client.get(
+            self.base_url, {"resourceType": "ca"}, format="json", **headers
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response.content)
+
+    def test_get_ca_allowed_with_claim_administrator_right(self):
+        user = _restricted_user(
+            ["gql_query_claim_administrator_perms"], "practitioner_ca_rights"
+        )
+        headers = _bearer_headers_for(user)
+
+        response = self.client.get(
+            self.base_url, {"resourceType": "ca"}, format="json", **headers
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+
+
+class PractitionerEnrolmentOfficerPermissionAPITests(GenericFhirAPITestMixin, APITestCase):
+    """
+    FHIRApiPractitionerOfficerPermissions.permissions_get used to be `[]`,
+    so any authenticated user could list every enrolment officer nationwide.
+    It now requires CoreConfig.gql_query_enrolment_officers_perms.
+    """
+
+    base_url = GeneralConfiguration.get_base_url() + "Practitioner/"
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.test_officer = create_test_officer()
+
+    def test_get_eo_forbidden_without_any_practitioner_right(self):
+        user = _restricted_user([], "practitioner_no_rights_eo")
+        headers = _bearer_headers_for(user)
+
+        response = self.client.get(
+            self.base_url, {"resourceType": "eo"}, format="json", **headers
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response.content)
+
+    def test_get_eo_allowed_with_enrolment_officer_right(self):
+        user = _restricted_user(
+            ["gql_query_enrolment_officers_perms"], "practitioner_eo_rights"
+        )
+        headers = _bearer_headers_for(user)
+
+        response = self.client.get(
+            self.base_url, {"resourceType": "eo"}, format="json", **headers
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)

--- a/api_fhir_r4/tests/utils.py
+++ b/api_fhir_r4/tests/utils.py
@@ -35,19 +35,28 @@ def load_and_replace_json(path=None, sub_str={}):
 #        self.json_representation = load_and_replace_json(_test_json_request_path,self.sub_str)
 _TEST_USER_NAME = "Admin"
 _TEST_USER_PASSWORD = "admin123"
-_TEST_DATA_USER = {
-    "username": _TEST_USER_NAME,
-    "password": _TEST_USER_PASSWORD,
-    "language": "en",
-    "roles": [create_admin_role().id],
-}
 
 
-def get_connection_payload(userdata=_TEST_DATA_USER):
+def _default_test_data_user():
+    # Built lazily (not as a module-level/default-argument value) so importing
+    # this module never touches the database - eager DB access at import time
+    # breaks test collection under pytest-django, which blocks DB access
+    # outside of a test's "django_db" context.
+    return {
+        "username": _TEST_USER_NAME,
+        "password": _TEST_USER_PASSWORD,
+        "language": "en",
+        "roles": [create_admin_role().id],
+    }
+
+
+def get_connection_payload(userdata=None):
+    userdata = userdata or _default_test_data_user()
     return {"username": userdata["username"], "password": userdata["password"]}
 
 
-def get_or_create_user_api(userdata=_TEST_DATA_USER):
+def get_or_create_user_api(userdata=None):
+    userdata = userdata or _default_test_data_user()
     user = create_test_interactive_user(**userdata)
     return user
 

--- a/api_fhir_r4/views/fhir/communication.py
+++ b/api_fhir_r4/views/fhir/communication.py
@@ -39,7 +39,7 @@ class CommunicationViewSet(
         return response
 
     def get_queryset(self):
-        queryset = Feedback.objects.all().order_by("validity_from")
+        queryset = Feedback.get_queryset(None, self.request.user).order_by("validity_from")
         return ValidityFromRequestParameterFilter(self.request).filter_queryset(
             queryset
         )

--- a/api_fhir_r4/views/fhir/group.py
+++ b/api_fhir_r4/views/fhir/group.py
@@ -39,7 +39,7 @@ class GroupViewSet(
         return response
 
     def get_queryset(self):
-        queryset = Family.objects.all().order_by("validity_from")
+        queryset = Family.get_queryset(None, self.request.user).order_by("validity_from")
         return ValidityFromRequestParameterFilter(self.request).filter_queryset(
             queryset
         )

--- a/api_fhir_r4/views/fhir/invoice.py
+++ b/api_fhir_r4/views/fhir/invoice.py
@@ -92,11 +92,11 @@ class InvoiceViewSet(
         return Invoice.objects
 
     def _invoice_queryset(self):
-        queryset = Invoice.objects.filter(is_deleted=False).order_by("date_created")
+        queryset = Invoice.get_queryset(None, self.request.user).order_by("date_created")
         return DateUpdatedRequestParameterFilter(self.request).filter_queryset(queryset)
 
     def _bill_queryset(self):
-        queryset = Bill.objects.filter(is_deleted=False).order_by("date_created")
+        queryset = Bill.get_queryset(None, self.request.user).order_by("date_created")
         return DateUpdatedRequestParameterFilter(self.request).filter_queryset(queryset)
 
     @classmethod

--- a/api_fhir_r4/views/fhir/organisation.py
+++ b/api_fhir_r4/views/fhir/organisation.py
@@ -253,7 +253,7 @@ class OrganisationViewSet(
         return HealthFacility.objects
 
     def _hf_queryset(self):
-        queryset = HealthFacility.objects.filter(validity_to__isnull=True).order_by(
+        queryset = HealthFacility.get_queryset(None, self.request.user).order_by(
             "validity_from"
         )
         return ValidityFromRequestParameterFilter(self.request).filter_queryset(
@@ -261,9 +261,9 @@ class OrganisationViewSet(
         )
 
     def _ph_queryset(self):
-        queryset = PolicyHolder.objects.filter(is_deleted=False).order_by(
-            "date_created"
-        )
+        queryset = PolicyHolder.get_queryset(None, self.request.user).filter(
+            is_deleted=False
+        ).order_by("date_created")
         return DateUpdatedRequestParameterFilter(self.request).filter_queryset(queryset)
 
     def _io_queryset(self):

--- a/api_fhir_r4/views/fhir/payment_notice.py
+++ b/api_fhir_r4/views/fhir/payment_notice.py
@@ -39,7 +39,7 @@ class PaymentNoticeViewSet(
         return response
 
     def get_queryset(self):
-        queryset = PaymentInvoice.objects.filter(is_deleted=False).order_by(
+        queryset = PaymentInvoice.get_queryset(None, self.request.user).order_by(
             "date_created"
         )
         return DateUpdatedRequestParameterFilter(self.request).filter_queryset(queryset)

--- a/api_fhir_r4/views/fhir/practitioner.py
+++ b/api_fhir_r4/views/fhir/practitioner.py
@@ -93,17 +93,18 @@ class PractitionerViewSet(
         return ClaimAdmin.objects
 
     def _ca_queryset(self):
-        queryset = ClaimAdmin.objects.filter(validity_to__isnull=True).all()
+        queryset = ClaimAdmin.get_queryset(None, self.request.user)
         return ValidityFromRequestParameterFilter(self.request).filter_queryset(
             queryset
         )
 
     def _eo_queryset(self):
-        queryset = (
+        base_queryset = (
             Officer.objects.filter(validity_to__isnull=True)
             .order_by("validity_from")
             .all()
         )
+        queryset = Officer.get_queryset(base_queryset, self.request.user)
         return ValidityFromRequestParameterFilter(self.request).filter_queryset(
             queryset
         )

--- a/api_fhir_r4/views/fhir/practitioner_role.py
+++ b/api_fhir_r4/views/fhir/practitioner_role.py
@@ -91,17 +91,19 @@ class PractitionerRoleViewSet(
         return ClaimAdmin.objects
 
     def _ca_queryset(self):
-        queryset = ClaimAdmin.objects.filter(validity_to__isnull=True).order_by(
+        base_queryset = ClaimAdmin.objects.filter(validity_to__isnull=True).order_by(
             "validity_from"
         )
+        queryset = ClaimAdmin.get_queryset(base_queryset, self.request.user)
         return ValidityFromRequestParameterFilter(self.request).filter_queryset(
             queryset
         )
 
     def _eo_queryset(self):
-        queryset = Officer.objects.filter(validity_to__isnull=True).order_by(
+        base_queryset = Officer.objects.filter(validity_to__isnull=True).order_by(
             "validity_from"
         )
+        queryset = Officer.get_queryset(base_queryset, self.request.user)
         return ValidityFromRequestParameterFilter(self.request).filter_queryset(
             queryset
         )


### PR DESCRIPTION
Replace app config permission lists with centralized rights constants in FHIR permission classes. Also pass request.user to get_queryset in the multiserializer permission check to align with the updated queryset signature, and add tests for the new permission behavior.


# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
